### PR TITLE
Run emacs tests using the real build directory used in cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ set(EGIT_TESTS refcount reference repository)
 
 foreach(test ${EGIT_TESTS})
   add_test(NAME libegit2_${test} COMMAND
-    emacs --batch -L . -L "${CMAKE_CURRENT_SOURCE_DIR}/test"
-    -l test-helper -l ${test}-test -f ert-run-tests-batch-and-exit)
+    emacs --batch
+          -L "${CMAKE_CURRENT_SOURCE_DIR}"
+          -L "${CMAKE_CURRENT_SOURCE_DIR}/test"
+          --eval "(setq libgit--build-dir \"${CMAKE_CURRENT_BINARY_DIR}\")"
+          --eval "(require 'libgit)"
+          -l test-helper
+          -l ${test}-test
+          -f ert-run-tests-batch-and-exit)
 endforeach(test)


### PR DESCRIPTION
With this change we can create the `build` directory anywhere we want to run the tests. The `${CMAKE_CURRENT_BINARY_DIR}` variable contains the real location of the `build` dir specified by the user at the moment of running cmake.

The actual `CMakeLists.txt` expect a `build` subdirectory inside the libegit2 root dir, but it's common to create the cmake build directory outside the source code library.