### PR TITLE
Build Emacs on Appveyor

### DIFF
--- a/.appveyor-script.ps1
+++ b/.appveyor-script.ps1
@@ -2,7 +2,7 @@
 # Instead, we store the stdout/stderr and grep for "FAILED".
 function Run-Test {
     param( $TestName )
-    $command = "emacs --batch -L build -L test -l libegit2 -l test-helper -l $($TestName)-test -f ert-run-tests-batch-and-exit"
+    $command = "C:\emacs\bin\emacs --batch -L build -L test -l libegit2 -l test-helper -l $($TestName)-test -f ert-run-tests-batch-and-exit"
     $output = Invoke-Expression "$command 2>&1"
     Write-Host $output
     if ($output | select-string -Pattern "FAILED") {

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ cache:
 
 env:
   global:
-    - EMACSCONFFLAGS="--with-x-toolkit=no --without-x --without-all --with-xml2 --with-modules --with-toolkit-scroll-bars=yes --with-gameuser=$USER"
     - PATH="$HOME/bin:$PATH"
+    - EMAKE_SHA1=1b23379eb5a9f82d3e2d227d0f217864e40f23e0
   matrix:
     - EMACS_VERSION=25.1
+    - EMACS_VERSION=25.2
     - EMACS_VERSION=25.3
     - EMACS_VERSION=26.1
     - EMACS_VERSION=snapshot
@@ -26,9 +27,10 @@ matrix:
     - env: EMACS_VERSION=snapshot
 
 before_install:
+  - wget "https://raw.githubusercontent.com/vermiculus/emake.el/${EMAKE_SHA1}/emake.mk"
   - make emacs
-  - make emake.el
 
 script:
   - make build/libegit2.so
+  - make compile
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ env:
     - PATH="$HOME/bin:$PATH"
     - EMAKE_SHA1=1b23379eb5a9f82d3e2d227d0f217864e40f23e0
   matrix:
-    - EMACS_VERSION=25.1
-    - EMACS_VERSION=25.2
     - EMACS_VERSION=25.3
     - EMACS_VERSION=26.1
     - EMACS_VERSION=snapshot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,21 @@
 environment:
+  global:
+    GENERATOR: "MinGW Makefiles"
   matrix:
-    - GENERATOR: "MinGW Makefiles"
+    # - EMACS_VERSION: "25.1"
+    # - EMACS_VERSION: "25.2"
+    - EMACS_VERSION: "25.3"
+    - EMACS_VERSION: "26.1"
+    - EMACS_VERSION: "snapshot"
 
 install:
   - git submodule update --init --recursive
-  # Use the chocolatey emacs64 package for testing
-  # TODO: Any better solutions? Build Emacs ourselves? What about 64-bit?
-  - cinst emacs64
+  - set MSYSTEM=MINGW64
+  - C:\msys64\usr\bin\bash -l -c "cd /c/projects/libegit2 && make -f emacs-appveyor.mk install_emacs"
 
 before_build:
   - set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
-  - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
+  - set PATH=C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\emacs;%PATH%
 
 build_script:
   - mkdir build

--- a/emacs-appveyor.mk
+++ b/emacs-appveyor.mk
@@ -1,0 +1,87 @@
+# Copyright (c) 2018      Magit contributors
+# Copyright (c) 2017-2018 Flycheck contributors
+# Copyright (c) 2015-2016 Sebastian Wiesner <swiesner@lunaryorn.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.EMACS_VERSION ?= 25.3
+
+
+MAKE_JOBS ?= 2
+
+# Tear the version apart
+VERSION_PARTS := $(subst -, ,$(EMACS_VERSION))
+VERSION_PART := $(word 1,$(VERSION_PARTS))
+PRE_RELEASE_PART := $(word 2,$(VERSION_PARTS))
+MAJOR_VERSION := $(word 1,$(subst ., ,$(EMACS_VERSION)))
+# Whether the version is a release candidate
+PRETEST ?= $(findstring rc,$(PRE_RELEASE_PART))
+
+# Build a minimal Emacs with no special flags, to build as fast as possible
+ifndef EMACSCONFFLAGS
+EMACSCONFFLAGS := --with-modules --with-gnutls=no --prefix=/c/emacs CFLAGS='-O2 -march=native' CXXFLAGS='-O2 -march=native'
+endif
+
+# Clone Emacs from the Github mirror because it's way faster than upstream
+EMACS_GIT_URL = https://github.com/emacs-mirror/emacs.git
+ifeq ($(PRETEST),)
+EMACS_FTP_URL = "https://ftp.gnu.org/gnu/emacs"
+else
+EMACS_FTP_URL = "http://alpha.gnu.org/pub/gnu/emacs/pretest"
+endif
+EMACS_TAR_URL = $(EMACS_FTP_URL)/emacs-$(EMACS_VERSION).tar.xz
+
+# If it's an RC the real reported Emacs version is the version without the
+# prerelease postfix.  Otherwise it's just the version that we get.
+ifneq ($(PRETEST),)
+REPORTED_EMACS_VERSION = $(VERSION_PART)
+else
+REPORTED_EMACS_VERSION = $(EMACS_VERSION)
+endif
+
+CONFIGUREFLAGS = --quiet --enable-silent-rules --prefix="$(HOME)"
+
+.PHONY: download_emacs_stable clone_emacs_snapshot
+.PHONY: configure_emacs install_emacs
+
+download_emacs_stable:
+	mkdir tmp
+	echo "Download Emacs $(EMACS_VERSION) from $(EMACS_TAR_URL)"
+	curl -o "tmp/emacs-$(EMACS_VERSION).tar.xz" "$(EMACS_TAR_URL)"
+	tar xf "tmp/emacs-$(EMACS_VERSION).tar.xz" -C tmp
+	mkdir -p `dirname "$(EMACS_DIR)"`
+	mv tmp/emacs-$(REPORTED_EMACS_VERSION) "$(EMACS_DIR)"
+
+clone_emacs_snapshot:
+	echo "Clone Emacs from Git"
+	git clone -q --depth=1 '$(EMACS_GIT_URL)' $(EMACS_DIR)
+	cd $(EMACS_DIR) && ./autogen.sh
+
+configure_emacs:
+	echo "Configure Emacs $(EMACS_VERSION)"
+	cd "$(EMACS_DIR)" && ./configure $(CONFIGUREFLAGS) $(EMACSCONFFLAGS) $(SILENT)
+
+EMACS_DIR = tmp/emacs
+ifeq ($(EMACS_VERSION),snapshot)
+configure_emacs: clone_emacs_snapshot
+else
+configure_emacs: download_emacs_stable
+endif
+
+install_emacs: configure_emacs
+	echo "Install Emacs $(EMACS_VERSION)"
+	make -C "$(EMACS_DIR)" -j$(MAKE_JOBS) install prefix=/c/emacs


### PR DESCRIPTION
This adds an `emacs-appveyor.mk` that is the spiritual complement of `emacs-travis.mk`. It doesn't have all the bells and whistles of the latter though, I just tore out the things I didn't need and made sure it worked for our use cases.

This PR also disables CI for 25.1 and 25.2. They take a while to run and presumably 25.3 should suffice for the 25.x line.

This should bring Windows CI up to par with Linux and OSX.