### PR TITLE
Functions for config inspection and manipulation

### DIFF
--- a/.appveyor-script.ps1
+++ b/.appveyor-script.ps1
@@ -16,6 +16,7 @@ function Run-Test {
 Run-Test -TestName "blame"
 Run-Test -TestName "branch"
 Run-Test -TestName "commit"
+Run-Test -TestName "config"
 Run-Test -TestName "ignore"
 Run-Test -TestName "refcount"
 Run-Test -TestName "reference"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ enable_testing()
 
 # NOTE: These test names must be replicated in .appveyor-script.ps1
 # for the Windows CI. Fixing this is still TODO.
-set(EGIT_TESTS blame branch commit ignore refcount reference repository signature status)
+set(EGIT_TESTS blame branch commit config ignore refcount reference repository signature status)
 
 foreach(test ${EGIT_TESTS})
   add_test(NAME libegit2_${test} COMMAND

--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ Probably none of these functions will be necessary, since we can expose OIDs to 
 
 - :x: `git-repository--cleanup` (in `sys`)
 - :heavy_check_mark: `git-repository-commondir`
-- :interrobang: `git-repository-config`
+- :heavy_check_mark: `git-repository-config`
 - :interrobang: `git-repository-config-snapshot`
 - :heavy_check_mark: `git-repository-detach-head`
 - :heavy_check_mark: `git-repository-discover`

--- a/README.md
+++ b/README.md
@@ -296,27 +296,27 @@ Probably none of these functions are necessary, since we can expose buffers to E
 - :interrobang: `git-config-delete-entry`
 - :interrobang: `git-config-delete-multivar`
 - :x: `git-config-entry-free` (memory management shouldn't be exposed to Emacs)
-- :interrobang: `git-config-find-global`
-- :interrobang: `git-config-find-programdata`
-- :interrobang: `git-config-find-system`
-- :interrobang: `git-config-find-xdg`
+- :heavy_check_mark: `git-config-find-global`
+- :heavy_check_mark: `git-config-find-programdata`
+- :heavy_check_mark: `git-config-find-system`
+- :heavy_check_mark: `git-config-find-xdg`
 - :interrobang: `git-config-foreach`
 - :interrobang: `git-config-foreach-match`
 - :x: `git-config-free` (memory management shouldn't be exposed to Emacs)
-- :interrobang: `git-config-get-bool`
+- :heavy_check_mark: `git-config-get-bool`
 - :interrobang: `git-config-get-entry`
-- :interrobang: `git-config-get-int32`
-- :interrobang: `git-config-get-int64`
+- :x: `git-config-get-int32` (don't need different integer types)
+- :heavy_check_mark: `git-config-get-int64` (as `-int`)
 - :interrobang: `git-config-get-mapped`
 - :interrobang: `git-config-get-multivar-foreach`
-- :interrobang: `git-config-get-path`
-- :interrobang: `git-config-get-string`
-- :interrobang: `git-config-get-string-buf`
+- :heavy_check_mark: `git-config-get-path`
+- :heavy_check_mark: `git-config-get-string`
+- :x: `git-config-get-string-buf` (probably fine with just `-get-string`)
 - :interrobang: `git-config-init-backend`
 - :x: `git-config-iterator-free` (memory management shouldn't be exposed to Emacs)
 - :interrobang: `git-config-iterator-glob-new`
 - :interrobang: `git-config-iterator-new`
-- :interrobang: `git-config-lock`
+- :heavy_check_mark: `git-config-lock`
 - :interrobang: `git-config-lookup-map-value`
 - :interrobang: `git-config-multivar-iterator-new`
 - :interrobang: `git-config-new`
@@ -329,11 +329,11 @@ Probably none of these functions are necessary, since we can expose buffers to E
 - :interrobang: `git-config-parse-int32`
 - :interrobang: `git-config-parse-int64`
 - :interrobang: `git-config-parse-path`
-- :interrobang: `git-config-set-bool`
-- :interrobang: `git-config-set-int32`
-- :interrobang: `git-config-set-int64`
+- :heavy_check_mark: `git-config-set-bool`
+- :x: `git-config-set-int32` (don't need different integer types)
+- :heavy_check_mark: `git-config-set-int64` (as `-int`)
 - :interrobang: `git-config-set-multivar`
-- :interrobang: `git-config-set-string`
+- :heavy_check_mark: `git-config-set-string`
 - :interrobang: `git-config-snapshot`
 
 ### cred

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -23,6 +23,22 @@ emacs_value egit_config_snapshot(emacs_env *env, emacs_value _config)
 // =============================================================================
 // Getters
 
+EGIT_DOC(config_get_bool, "CONFIG NAME",
+         "Get the value of NAME in CONFIG as a boolean (`t' or `nil').\n"
+         "CONFIG must be a snapshot, see `libgit-config-snapshot'.");
+emacs_value egit_config_get_bool(emacs_env *env, emacs_value _config, emacs_value _name)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    EGIT_ASSERT_STRING(_name);
+    git_config *config = EGIT_EXTRACT(_config);
+    char *name = EGIT_EXTRACT_STRING(_name);
+    int value;
+    int retval = git_config_get_bool(&value, config, name);
+    free(name);
+    EGIT_CHECK_ERROR(retval);
+    return value ? em_t : em_nil;
+}
+
 EGIT_DOC(config_get_int, "CONFIG NAME",
          "Get the value of NAME in CONFIG as an integer.\n"
          "CONFIG must be a snapshot, see `libgit-config-snapshot'.");
@@ -69,6 +85,19 @@ emacs_value egit_config_lock(emacs_env *env, emacs_value _config)
 
 // =============================================================================
 // Setters
+
+EGIT_DOC(config_set_bool, "CONFIG NAME VALUE", "Set the value of NAME in CONFIG to VALUE.");
+emacs_value egit_config_set_bool(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    EGIT_ASSERT_STRING(_name);
+    git_config *config = EGIT_EXTRACT(_config);
+    const char *name = EGIT_EXTRACT_STRING(_name);
+    int value = EGIT_EXTRACT_BOOLEAN(_value);
+    int retval = git_config_set_bool(config, name, value);
+    EGIT_CHECK_ERROR(retval);
+    return em_nil;
+}
 
 EGIT_DOC(config_set_int, "CONFIG NAME VALUE", "Set the value of NAME in CONFIG to VALUE.");
 emacs_value egit_config_set_int(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -126,3 +126,55 @@ emacs_value egit_config_set_string(emacs_env *env, emacs_value _config, emacs_va
     EGIT_CHECK_ERROR(retval);
     return em_nil;
 }
+
+
+// =============================================================================
+// Miscellaneous
+
+EGIT_DOC(config_find_global, "", "Get the path to the global config file.");
+emacs_value egit_config_find_global(emacs_env *env)
+{
+    git_buf out = {0};
+    int retval = git_config_find_global(&out);
+    EGIT_CHECK_ERROR(retval);
+    emacs_value ret = env->make_string(env, out.ptr, out.size);
+    EGIT_NORMALIZE_PATH(ret);
+    git_buf_free(&out);
+    return ret;
+}
+
+EGIT_DOC(config_find_programdata, "", "Get the path to the config file in ProgramData.");
+emacs_value egit_config_find_programdata(emacs_env *env)
+{
+    git_buf out = {0};
+    int retval = git_config_find_programdata(&out);
+    EGIT_CHECK_ERROR(retval);
+    emacs_value ret = env->make_string(env, out.ptr, out.size);
+    EGIT_NORMALIZE_PATH(ret);
+    git_buf_free(&out);
+    return ret;
+}
+
+EGIT_DOC(config_find_system, "", "Get the path to the system config file.");
+emacs_value egit_config_find_system(emacs_env *env)
+{
+    git_buf out = {0};
+    int retval = git_config_find_system(&out);
+    EGIT_CHECK_ERROR(retval);
+    emacs_value ret = env->make_string(env, out.ptr, out.size);
+    EGIT_NORMALIZE_PATH(ret);
+    git_buf_free(&out);
+    return ret;
+}
+
+EGIT_DOC(config_find_xdg, "", "Get the path to the XDG config file.");
+emacs_value egit_config_find_xdg(emacs_env *env)
+{
+    git_buf out = {0};
+    int retval = git_config_find_xdg(&out);
+    EGIT_CHECK_ERROR(retval);
+    emacs_value ret = env->make_string(env, out.ptr, out.size);
+    EGIT_NORMALIZE_PATH(ret);
+    git_buf_free(&out);
+    return ret;
+}

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -23,6 +23,22 @@ emacs_value egit_config_snapshot(emacs_env *env, emacs_value _config)
 // =============================================================================
 // Getters
 
+EGIT_DOC(config_get_int, "CONFIG NAME",
+         "Get the value of NAME in CONFIG as an integer.\n"
+         "CONFIG must be a snapshot, see `libgit-config-snapshot'.");
+emacs_value egit_config_get_int(emacs_env *env, emacs_value _config, emacs_value _name)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    EGIT_ASSERT_STRING(_name);
+    git_config *config = EGIT_EXTRACT(_config);
+    char *name = EGIT_EXTRACT_STRING(_name);
+    int64_t value;
+    int retval = git_config_get_int64(&value, config, name);
+    free(name);
+    EGIT_CHECK_ERROR(retval);
+    return env->make_integer(env, value);
+}
+
 EGIT_DOC(config_get_string, "CONFIG NAME",
          "Get the value of NAME in CONFIG as a string.\n"
          "CONFIG must be a snapshot, see `libgit-config-snapshot'.");
@@ -53,6 +69,20 @@ emacs_value egit_config_lock(emacs_env *env, emacs_value _config)
 
 // =============================================================================
 // Setters
+
+EGIT_DOC(config_set_int, "CONFIG NAME VALUE", "Set the value of NAME in CONFIG to VALUE.");
+emacs_value egit_config_set_int(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    EGIT_ASSERT_STRING(_name);
+    EGIT_ASSERT_INTEGER(_value);
+    git_config *config = EGIT_EXTRACT(_config);
+    const char *name = EGIT_EXTRACT_STRING(_name);
+    int64_t value = EGIT_EXTRACT_INTEGER(_value);
+    int retval = git_config_set_int64(config, name, value);
+    EGIT_CHECK_ERROR(retval);
+    return em_nil;
+}
 
 EGIT_DOC(config_set_string, "CONFIG NAME VALUE", "Set the value of NAME in CONFIG to VALUE.");
 emacs_value egit_config_set_string(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -18,3 +18,23 @@ emacs_value egit_config_snapshot(emacs_env *env, emacs_value _config)
     EGIT_CHECK_ERROR(retval);
     return egit_wrap(env, EGIT_CONFIG, snapshot);
 }
+
+
+// =============================================================================
+// Getters
+
+EGIT_DOC(config_get_string, "CONFIG NAME",
+         "Get the value of NAME in CONFIG as a string.\n"
+         "CONFIG must be a snapshot, see `libgit-config-snapshot'.");
+emacs_value egit_config_get_string(emacs_env *env, emacs_value _config, emacs_value _name)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    EGIT_ASSERT_STRING(_name);
+    git_config *config = EGIT_EXTRACT(_config);
+    char *name = EGIT_EXTRACT_STRING(_name);
+    const char *value;
+    int retval = git_config_get_string(&value, config, name);
+    free(name);
+    EGIT_CHECK_ERROR(retval);
+    return env->make_string(env, value, strlen(value));
+}

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -38,3 +38,32 @@ emacs_value egit_config_get_string(emacs_env *env, emacs_value _config, emacs_va
     EGIT_CHECK_ERROR(retval);
     return env->make_string(env, value, strlen(value));
 }
+
+EGIT_DOC(config_lock, "CONFIG", "Lock the highest priority backend in CONFIG.");
+emacs_value egit_config_lock(emacs_env *env, emacs_value _config)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    git_config *config = EGIT_EXTRACT(_config);
+    git_transaction *trans;
+    int retval = git_config_lock(&trans, config);
+    EGIT_CHECK_ERROR(retval);
+    return egit_wrap(env, EGIT_TRANSACTION, trans);
+}
+
+
+// =============================================================================
+// Setters
+
+EGIT_DOC(config_set_string, "CONFIG NAME VALUE", "Set the value of NAME in CONFIG to VALUE.");
+emacs_value egit_config_set_string(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    EGIT_ASSERT_STRING(_name);
+    EGIT_ASSERT_STRING(_value);
+    git_config *config = EGIT_EXTRACT(_config);
+    const char *name = EGIT_EXTRACT_STRING(_name);
+    const char *value = EGIT_EXTRACT_STRING(_value);
+    int retval = git_config_set_string(config, name, value);
+    EGIT_CHECK_ERROR(retval);
+    return em_nil;
+}

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -55,6 +55,29 @@ emacs_value egit_config_get_int(emacs_env *env, emacs_value _config, emacs_value
     return env->make_integer(env, value);
 }
 
+EGIT_DOC(config_get_path, "CONFIG NAME",
+         "Get the value of NAME in CONFIG as a string path.\n"
+         "This is similar to `libgit-config-get-string' except the path\n"
+         "is automatically normalized.\n"
+         "CONFIG must be a snapshot, see `libgit-config-snapshot'.");
+emacs_value egit_config_get_path(emacs_env *env, emacs_value _config, emacs_value _name)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    EGIT_ASSERT_STRING(_name);
+    git_config *config = EGIT_EXTRACT(_config);
+    char *name = EGIT_EXTRACT_STRING(_name);
+    const char *value;
+    int retval = git_config_get_path(&value, config, name);
+    free(name);
+    EGIT_CHECK_ERROR(retval);
+
+    // git_config_get_path does some normalization,
+    // but I trust Emacs' path normalization to be more thorough.
+    emacs_value ret = env->make_string(env, value, strlen(value));
+    EGIT_NORMALIZE_PATH(ret);
+    return ret;
+}
+
 EGIT_DOC(config_get_string, "CONFIG NAME",
          "Get the value of NAME in CONFIG as a string.\n"
          "CONFIG must be a snapshot, see `libgit-config-snapshot'.");

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -1,0 +1,20 @@
+#include "git2.h"
+
+#include "egit.h"
+#include "interface.h"
+#include "egit-config.h"
+
+
+// =============================================================================
+// Constructors
+
+EGIT_DOC(config_snapshot, "CONFIG", "Create a consistent snapshot of CONFIG.");
+emacs_value egit_config_snapshot(emacs_env *env, emacs_value _config)
+{
+    EGIT_ASSERT_CONFIG(_config);
+    git_config *config = EGIT_EXTRACT(_config);
+    git_config *snapshot;
+    int retval = git_config_snapshot(&snapshot, config);
+    EGIT_CHECK_ERROR(retval);
+    return egit_wrap(env, EGIT_CONFIG, snapshot);
+}

--- a/src/egit-config.h
+++ b/src/egit-config.h
@@ -14,4 +14,9 @@ EGIT_DEFUN(config_set_bool, emacs_value _config, emacs_value _name, emacs_value 
 EGIT_DEFUN(config_set_int, emacs_value _config, emacs_value _name, emacs_value _value);
 EGIT_DEFUN(config_set_string, emacs_value _config, emacs_value _name, emacs_value _value);
 
+EGIT_DEFUN_0(config_find_global);
+EGIT_DEFUN_0(config_find_programdata);
+EGIT_DEFUN_0(config_find_system);
+EGIT_DEFUN_0(config_find_xdg);
+
 #endif /* EGIT_CONFIG_H */

--- a/src/egit-config.h
+++ b/src/egit-config.h
@@ -5,10 +5,12 @@
 
 EGIT_DEFUN(config_snapshot, emacs_value _config);
 
+EGIT_DEFUN(config_get_bool, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_get_int, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_get_string, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_lock, emacs_value _config);
 
+EGIT_DEFUN(config_set_bool, emacs_value _config, emacs_value _name, emacs_value _value);
 EGIT_DEFUN(config_set_int, emacs_value _config, emacs_value _name, emacs_value _value);
 EGIT_DEFUN(config_set_string, emacs_value _config, emacs_value _name, emacs_value _value);
 

--- a/src/egit-config.h
+++ b/src/egit-config.h
@@ -6,5 +6,8 @@
 EGIT_DEFUN(config_snapshot, emacs_value _config);
 
 EGIT_DEFUN(config_get_string, emacs_value _config, emacs_value _name);
+EGIT_DEFUN(config_lock, emacs_value _config);
+
+EGIT_DEFUN(config_set_string, emacs_value _config, emacs_value _name, emacs_value _value);
 
 #endif /* EGIT_CONFIG_H */

--- a/src/egit-config.h
+++ b/src/egit-config.h
@@ -1,0 +1,8 @@
+#include "egit.h"
+
+#ifndef EGIT_CONFIG_H
+#define EGIT_CONFIG_H
+
+EGIT_DEFUN(config_snapshot, emacs_value _config);
+
+#endif /* EGIT_CONFIG_H */

--- a/src/egit-config.h
+++ b/src/egit-config.h
@@ -5,4 +5,6 @@
 
 EGIT_DEFUN(config_snapshot, emacs_value _config);
 
+EGIT_DEFUN(config_get_string, emacs_value _config, emacs_value _name);
+
 #endif /* EGIT_CONFIG_H */

--- a/src/egit-config.h
+++ b/src/egit-config.h
@@ -5,9 +5,11 @@
 
 EGIT_DEFUN(config_snapshot, emacs_value _config);
 
+EGIT_DEFUN(config_get_int, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_get_string, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_lock, emacs_value _config);
 
+EGIT_DEFUN(config_set_int, emacs_value _config, emacs_value _name, emacs_value _value);
 EGIT_DEFUN(config_set_string, emacs_value _config, emacs_value _name, emacs_value _value);
 
 #endif /* EGIT_CONFIG_H */

--- a/src/egit-config.h
+++ b/src/egit-config.h
@@ -7,6 +7,7 @@ EGIT_DEFUN(config_snapshot, emacs_value _config);
 
 EGIT_DEFUN(config_get_bool, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_get_int, emacs_value _config, emacs_value _name);
+EGIT_DEFUN(config_get_path, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_get_string, emacs_value _config, emacs_value _name);
 EGIT_DEFUN(config_lock, emacs_value _config);
 

--- a/src/egit-repository.c
+++ b/src/egit-repository.c
@@ -84,6 +84,17 @@ emacs_value egit_repository_commondir(emacs_env *env, emacs_value _repo)
     return retval;
 }
 
+EGIT_DOC(repository_config, "REPO", "Return the git config associated with REPO.");
+emacs_value egit_repository_config(emacs_env *env, emacs_value _repo)
+{
+    EGIT_ASSERT_REPOSITORY(_repo);
+    git_repository *repo = EGIT_EXTRACT(_repo);
+    git_config *config;
+    int retval = git_repository_config(&config, repo);
+    EGIT_CHECK_ERROR(retval);
+    return egit_wrap(env, EGIT_CONFIG, config);
+}
+
 EGIT_DOC(repository_get_namespace, "REPO",
          "Return the currently active namespace for REPO, or nil.");
 emacs_value egit_repository_get_namespace(emacs_env *env, emacs_value _repo)

--- a/src/egit-repository.h
+++ b/src/egit-repository.h
@@ -8,6 +8,7 @@ EGIT_DEFUN(repository_open, emacs_value _path);
 EGIT_DEFUN(repository_open_bare, emacs_value _path);
 
 EGIT_DEFUN(repository_commondir, emacs_value _repo);
+EGIT_DEFUN(repository_config, emacs_value _repo);
 EGIT_DEFUN(repository_get_namespace, emacs_value _repo);
 EGIT_DEFUN(repository_head, emacs_value _repo);
 EGIT_DEFUN(repository_head_for_worktree, emacs_value _repo, emacs_value _name);

--- a/src/egit-transaction.c
+++ b/src/egit-transaction.c
@@ -1,0 +1,16 @@
+#include "git2.h"
+
+#include "egit.h"
+#include "interface.h"
+#include "egit-transaction.h"
+
+
+EGIT_DOC(transaction_commit, "TRANS", "Commit the changes made in TRANS.");
+emacs_value egit_transaction_commit(emacs_env *env, emacs_value _trans)
+{
+    EGIT_ASSERT_TRANSACTION(_trans);
+    git_transaction *trans = EGIT_EXTRACT(_trans);
+    int retval = git_transaction_commit(trans);
+    EGIT_CHECK_ERROR(retval);
+    return em_nil;
+}

--- a/src/egit-transaction.h
+++ b/src/egit-transaction.h
@@ -1,0 +1,8 @@
+#include "egit.h"
+
+#ifndef EGIT_TRANSACTION_H
+#define EGIT_TRANSACTION_H
+
+EGIT_DEFUN(transaction_commit, emacs_value _trans);
+
+#endif /* EGIT_TRANSACTION_H */

--- a/src/egit.c
+++ b/src/egit.c
@@ -378,10 +378,12 @@ void egit_init(emacs_env *env)
     // Config
     DEFUN("libgit-config-snapshot", config_snapshot, 1, 1);
 
+    DEFUN("libgit-config-get-bool", config_get_bool, 2, 2);
     DEFUN("libgit-config-get-int", config_get_int, 2, 2);
     DEFUN("libgit-config-get-string", config_get_string, 2, 2);
     DEFUN("libgit-config-lock", config_lock, 1, 1);
 
+    DEFUN("libgit-config-set-bool", config_set_bool, 3, 3);
     DEFUN("libgit-config-set-int", config_set_int, 3, 3);
     DEFUN("libgit-config-set-string", config_set_string, 3, 3);
 

--- a/src/egit.c
+++ b/src/egit.c
@@ -388,6 +388,7 @@ void egit_init(emacs_env *env)
 
     DEFUN("libgit-config-get-bool", config_get_bool, 2, 2);
     DEFUN("libgit-config-get-int", config_get_int, 2, 2);
+    DEFUN("libgit-config-get-path", config_get_path, 2, 2);
     DEFUN("libgit-config-get-string", config_get_string, 2, 2);
     DEFUN("libgit-config-lock", config_lock, 1, 1);
 

--- a/src/egit.c
+++ b/src/egit.c
@@ -7,6 +7,7 @@
 
 #include "interface.h"
 #include "egit-blame.h"
+#include "egit-branch.h"
 #include "egit-clone.h"
 #include "egit-commit.h"
 #include "egit-config.h"
@@ -17,7 +18,7 @@
 #include "egit-revparse.h"
 #include "egit-signature.h"
 #include "egit-status.h"
-#include "egit-branch.h"
+#include "egit-transaction.h"
 #include "egit.h"
 
 // Hash table of stored objects
@@ -378,6 +379,9 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-config-snapshot", config_snapshot, 1, 1);
 
     DEFUN("libgit-config-get-string", config_get_string, 2, 2);
+    DEFUN("libgit-config-lock", config_lock, 1, 1);
+
+    DEFUN("libgit-config-set-string", config_set_string, 3, 3);
 
     // Ignore
     DEFUN("libgit-ignore-add-rule", add_rule, 2, 2);
@@ -465,4 +469,7 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-status-file", status_file, 2, 2);
     DEFUN("libgit-status-should-ignore-p", status_should_ignore_p, 2, 2);
     DEFUN("libgit-status-foreach", status_foreach, 2, 6);
+
+    // Transaction
+    DEFUN("libgit-transaction-commit", transaction_commit, 1, 1);
 }

--- a/src/egit.c
+++ b/src/egit.c
@@ -9,6 +9,7 @@
 #include "egit-blame.h"
 #include "egit-clone.h"
 #include "egit-commit.h"
+#include "egit-config.h"
 #include "egit-ignore.h"
 #include "egit-object.h"
 #include "egit-reference.h"
@@ -286,7 +287,7 @@ static emacs_value egit_commit_p(emacs_env *env, emacs_value obj)
     return egit_get_type(env, obj) == EGIT_COMMIT ? em_t : em_nil;
 }
 
-EGIT_DOC(commit_p, "OBJ", "Return non-nil if OBJ is a git config.");
+EGIT_DOC(config_p, "OBJ", "Return non-nil if OBJ is a git config.");
 static emacs_value egit_config_p(emacs_env *env, emacs_value obj)
 {
     return egit_get_type(env, obj) == EGIT_CONFIG ? em_t : em_nil;
@@ -373,6 +374,9 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-commit-parent-id", commit_parent_id, 1, 2);
     DEFUN("libgit-commit-parentcount", commit_parentcount, 1, 1);
 
+    // Config
+    DEFUN("libgit-config-snapshot", config_snapshot, 1, 1);
+
     // Ignore
     DEFUN("libgit-ignore-add-rule", add_rule, 2, 2);
     DEFUN("libgit-ignore-clear-internal-rules", clear_internal_rules, 1, 1);
@@ -420,6 +424,7 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-repository-open-bare", repository_open_bare, 1, 1);
 
     DEFUN("libgit-repository-commondir", repository_commondir, 1, 1);
+    DEFUN("libgit-repository-config", repository_config, 1, 1);
     DEFUN("libgit-repository-get-namespace", repository_get_namespace, 1, 1);
     DEFUN("libgit-repository-head", repository_head, 1, 1);
     DEFUN("libgit-repository-head-for-worktree", repository_head_for_worktree, 2, 2);

--- a/src/egit.c
+++ b/src/egit.c
@@ -377,6 +377,8 @@ void egit_init(emacs_env *env)
     // Config
     DEFUN("libgit-config-snapshot", config_snapshot, 1, 1);
 
+    DEFUN("libgit-config-get-string", config_get_string, 2, 2);
+
     // Ignore
     DEFUN("libgit-ignore-add-rule", add_rule, 2, 2);
     DEFUN("libgit-ignore-clear-internal-rules", clear_internal_rules, 1, 1);

--- a/src/egit.c
+++ b/src/egit.c
@@ -378,9 +378,11 @@ void egit_init(emacs_env *env)
     // Config
     DEFUN("libgit-config-snapshot", config_snapshot, 1, 1);
 
+    DEFUN("libgit-config-get-int", config_get_int, 2, 2);
     DEFUN("libgit-config-get-string", config_get_string, 2, 2);
     DEFUN("libgit-config-lock", config_lock, 1, 1);
 
+    DEFUN("libgit-config-set-int", config_set_int, 3, 3);
     DEFUN("libgit-config-set-string", config_set_string, 3, 3);
 
     // Ignore

--- a/src/egit.c
+++ b/src/egit.c
@@ -123,6 +123,12 @@ static void egit_finalize(void* _obj)
         repo = git_object_owner(obj->ptr);
         git_object_free(obj->ptr);
         break;
+    case EGIT_BLAME:
+        git_blame_free(obj->ptr);
+        break;
+    case EGIT_CONFIG:
+        git_config_free(obj->ptr);
+        break;
     case EGIT_REFERENCE:
         repo = git_reference_owner(obj->ptr);
         git_reference_free(obj->ptr);
@@ -130,8 +136,8 @@ static void egit_finalize(void* _obj)
     case EGIT_SIGNATURE:
         git_signature_free(obj->ptr);
         break;
-    case EGIT_BLAME:
-        git_blame_free(obj->ptr);
+    case EGIT_TRANSACTION:
+        git_transaction_free(obj->ptr);
         break;
     default: break;
     }
@@ -262,6 +268,8 @@ static emacs_value egit_typeof(emacs_env *env, emacs_value val)
     case EGIT_TAG: return em_tag;
     case EGIT_OBJECT: return em_object;
     case EGIT_BLAME: return em_blame;
+    case EGIT_CONFIG: return em_config;
+    case EGIT_TRANSACTION: return em_transaction;
     default: return em_nil;
     }
 }
@@ -276,6 +284,12 @@ EGIT_DOC(commit_p, "OBJ", "Return non-nil if OBJ is a git commit.");
 static emacs_value egit_commit_p(emacs_env *env, emacs_value obj)
 {
     return egit_get_type(env, obj) == EGIT_COMMIT ? em_t : em_nil;
+}
+
+EGIT_DOC(commit_p, "OBJ", "Return non-nil if OBJ is a git config.");
+static emacs_value egit_config_p(emacs_env *env, emacs_value obj)
+{
+    return egit_get_type(env, obj) == EGIT_CONFIG ? em_t : em_nil;
 }
 
 EGIT_DOC(object_p, "OBJ", "Return non-nil if OBJ is a git object.");
@@ -298,10 +312,16 @@ static emacs_value egit_repository_p(emacs_env *env, emacs_value obj)
     return egit_get_type(env, obj) == EGIT_REPOSITORY ? em_t : em_nil;
 }
 
-EGIT_DOC(signature_p, "OBJ", "return non-nil if OBJ is a git signature.");
+EGIT_DOC(signature_p, "OBJ", "Return non-nil if OBJ is a git signature.");
 static emacs_value egit_signature_p(emacs_env *env, emacs_value obj)
 {
     return egit_get_type(env, obj) == EGIT_SIGNATURE ? em_t : em_nil;
+}
+
+EGIT_DOC(transaction_p, "OBJ", "Return non-nil if OBJ is a git transaction.");
+static emacs_value egit_transaction_p(emacs_env *env, emacs_value obj)
+{
+    return egit_get_type(env, obj) == EGIT_TRANSACTION ? em_t : em_nil;
 }
 
 #define DEFUN(ename, cname, min_nargs, max_nargs)                       \
@@ -319,10 +339,12 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-typeof", typeof, 1, 1);
     DEFUN("libgit-blame-p", blame_p, 1, 1);
     DEFUN("libgit-commit-p", commit_p, 1, 1);
+    DEFUN("libgit-config-p", config_p, 1, 1);
     DEFUN("libgit-object-p", object_p, 1, 1);
     DEFUN("libgit-reference-p", reference_p, 1, 1);
     DEFUN("libgit-repository-p", repository_p, 1, 1);
     DEFUN("libgit-signature-p", signature_p, 1, 1);
+    DEFUN("libgit-transaction-p", transaction_p, 1, 1);
 
     // Blame
     DEFUN("libgit-blame-file", blame_file, 2, 3);

--- a/src/egit.c
+++ b/src/egit.c
@@ -186,6 +186,7 @@ emacs_value egit_wrap(emacs_env *env, egit_type type, void* data)
     return env->make_user_ptr(env, egit_finalize, wrapper);
 }
 
+typedef emacs_value (*func_0)(emacs_env*);
 typedef emacs_value (*func_1)(emacs_env*, emacs_value);
 typedef emacs_value (*func_2)(emacs_env*, emacs_value, emacs_value);
 typedef emacs_value (*func_3)(emacs_env*, emacs_value, emacs_value, emacs_value);
@@ -198,6 +199,13 @@ typedef emacs_value (*func_6)(emacs_env*, emacs_value, emacs_value, emacs_value,
 
 // Get an argument index, or nil. Useful for simulating optional arguments.
 #define GET_SAFE(arglist, nargs, index) ((index) < (nargs) ? (arglist)[(index)] : em_nil)
+
+emacs_value egit_dispatch_0(emacs_env *env, __attribute__((unused)) ptrdiff_t nargs,
+                            __attribute__((unused)) emacs_value *args, void *data)
+{
+    func_0 func = (func_0) data;
+    return func(env);
+}
 
 emacs_value egit_dispatch_1(emacs_env *env, ptrdiff_t nargs, emacs_value *args, void *data)
 {
@@ -386,6 +394,11 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-config-set-bool", config_set_bool, 3, 3);
     DEFUN("libgit-config-set-int", config_set_int, 3, 3);
     DEFUN("libgit-config-set-string", config_set_string, 3, 3);
+
+    DEFUN("libgit-config-find-global", config_find_global, 0, 0);
+    DEFUN("libgit-config-find-programdata", config_find_programdata, 0, 0);
+    DEFUN("libgit-config-find-system", config_find_system, 0, 0);
+    DEFUN("libgit-config-find-xdg", config_find_xdg, 0, 0);
 
     // Ignore
     DEFUN("libgit-ignore-add-rule", add_rule, 2, 2);

--- a/src/egit.h
+++ b/src/egit.h
@@ -25,6 +25,13 @@
     emacs_value egit_##name(emacs_env *env, __VA_ARGS__)
 
 /**
+ * Variant of EGIT_DEFUN for zero parameters.
+ */
+#define EGIT_DEFUN_0(name)                      \
+    extern const char *egit_##name##__doc;      \
+    emacs_value egit_##name(emacs_env *env)
+
+/**
  * Assert that VAL is a string, signal an error and return otherwise.
  */
 #define EGIT_ASSERT_STRING(val)                                         \

--- a/src/egit.h
+++ b/src/egit.h
@@ -55,10 +55,16 @@
     do { if (!egit_assert_object(env, (val))) return em_nil; } while (0)
 
 /**
- * Assert that VAL is a git object, signal an error and return otherwise.
+ * Assert that VAL is a git commit, signal an error and return otherwise.
  */
 #define EGIT_ASSERT_COMMIT(val)                                         \
     do { if (!egit_assert_type(env, (val), EGIT_COMMIT, em_libgit_commit_p)) return em_nil; } while (0)
+
+/**
+ * Assert that VAL is a git config, signal an error and return otherwise.
+ */
+#define EGIT_ASSERT_CONFIG(val)                                         \
+    do { if (!egit_assert_type(env, (val), EGIT_CONFIG, em_libgit_config_p)) return em_nil; } while (0)
 
 /**
  * Assert that VAL is a git repository, signal an error and return otherwise.
@@ -77,6 +83,12 @@
  */
 #define EGIT_ASSERT_SIGNATURE(val)                                     \
     do { if (!egit_assert_type(env, (val), EGIT_SIGNATURE, em_libgit_signature_p)) return em_nil; } while (0)
+
+/**
+ * Assert that VAL is a transaction, signal an error and return otherwise.
+ */
+#define EGIT_ASSERT_TRANSACTION(val)                                    \
+    do { if (!egit_assert_type(env, (val), EGIT_TRANSACTION, em_libgit_transaction_p)) return em_nil; } while (0)
 
 /**
  * Assert that VAL is a signature or nil, signal an error and return otherwise.
@@ -191,7 +203,9 @@ typedef enum {
     EGIT_TAG,
     EGIT_OBJECT,
     EGIT_SIGNATURE,
-    EGIT_BLAME
+    EGIT_BLAME,
+    EGIT_CONFIG,
+    EGIT_TRANSACTION
 } egit_type;
 
 /**

--- a/src/interface.c
+++ b/src/interface.c
@@ -15,9 +15,10 @@ emacs_value em_nil, em_cons_p, em_integerp, em_stringp, em_t, em_symbol_value;
 
 // Git object predicates
 emacs_value em_libgit_object_p, em_libgit_repository_p, em_libgit_reference_p,
-    em_libgit_signature_p, em_libgit_blame_p, em_libgit_commit_p;
+    em_libgit_signature_p, em_libgit_blame_p, em_libgit_commit_p, em_libgit_config_p,
+    em_libgit_transaction_p;
 emacs_value em_repository, em_reference, em_commit, em_tree, em_blob, em_tag, em_object,
-    em_signature, em_blame;
+    em_signature, em_blame, em_config, em_transaction;
 
 // Repository states
 emacs_value em_merge, em_revert, em_revert_sequence, em_cherrypick,
@@ -82,6 +83,8 @@ void em_init(emacs_env *env)
     em_libgit_signature_p = GLOBREF(INTERN("libgit-signature-p"));
     em_libgit_blame_p = GLOBREF(INTERN("libgit-blame-p"));
     em_libgit_commit_p = GLOBREF(INTERN("libgit-commit-p"));
+    em_libgit_config_p = GLOBREF(INTERN("libgit-config-p"));
+    em_libgit_transaction_p = GLOBREF(INTERN("libgit-transaction-p"));
 
     em_repository = GLOBREF(INTERN("repository"));
     em_reference = GLOBREF(INTERN("reference"));
@@ -92,6 +95,8 @@ void em_init(emacs_env *env)
     em_object = GLOBREF(INTERN("object"));
     em_signature = GLOBREF(INTERN("signature"));
     em_blame = GLOBREF(INTERN("blame"));
+    em_config = GLOBREF(INTERN("config"));
+    em_transaction = GLOBREF(INTERN("transaction"));
 
     em_merge = GLOBREF(INTERN("merge"));
     em_revert = GLOBREF(INTERN("revert"));

--- a/src/interface.h
+++ b/src/interface.h
@@ -9,9 +9,10 @@ extern emacs_value em_nil, em_cons_p, em_integerp, em_stringp, em_t;
 
 // Git object predicates and types
 extern emacs_value em_libgit_object_p, em_libgit_repository_p, em_libgit_reference_p,
-    em_libgit_signature_p, em_libgit_blame_p, em_libgit_commit_p;
+    em_libgit_signature_p, em_libgit_blame_p, em_libgit_commit_p, em_libgit_config_p,
+    em_libgit_transaction_p;
 extern emacs_value em_repository, em_reference, em_commit, em_tree, em_blob, em_tag, em_object,
-    em_signature, em_blame;
+    em_signature, em_blame, em_transaction, em_config;
 
 // Repository states
 extern emacs_value em_merge, em_revert, em_revert_sequence, em_cherrypick,

--- a/test/config-test.el
+++ b/test/config-test.el
@@ -14,6 +14,10 @@
   money = 1k
   hairs = 1m
   atoms = 1g
+  male = yes
+  intelligent = off
+  handsome = 1
+  rich = false
 ")
     (let* ((repo (libgit-repository-open path))
            (config (libgit-repository-config repo))
@@ -25,7 +29,11 @@
       (should (= 7 (libgit-config-get-int snap "user.age")))
       (should (= 1024 (libgit-config-get-int snap "user.money")))
       (should (= (* 1024 1024) (libgit-config-get-int snap "user.hairs")))
-      (should (= (* 1024 1024 1024) (libgit-config-get-int snap "user.atoms"))))))
+      (should (= (* 1024 1024 1024) (libgit-config-get-int snap "user.atoms")))
+      (should (libgit-config-get-bool snap "user.male"))
+      (should-not (libgit-config-get-bool snap "user.intelligent"))
+      (should (libgit-config-get-bool snap "user.handsome"))
+      (should-not (libgit-config-get-bool snap "user.rich")))))
 
 (ert-deftest config-set ()
   (with-temp-dir path
@@ -51,4 +59,12 @@
 
       (libgit-config-set-int config "user.age" 7)
       (let ((snap (libgit-config-snapshot config)))
-        (should (= 7 (libgit-config-get-int snap "user.age")))))))
+        (should (= 7 (libgit-config-get-int snap "user.age"))))
+
+      (libgit-config-set-bool config "user.male" t)
+      (let ((snap (libgit-config-snapshot config)))
+        (should (libgit-config-get-bool snap "user.male")))
+
+      (libgit-config-set-bool config "user.intelligent" nil)
+      (let ((snap (libgit-config-snapshot config)))
+        (should-not (libgit-config-get-bool snap "user.intelligent"))))))

--- a/test/config-test.el
+++ b/test/config-test.el
@@ -1,0 +1,4 @@
+(ert-deftest repository-config ()
+  (with-temp-dir path
+    (init)
+    (should (libgit-config-p (libgit-repository-config (libgit-repository-open path))))))

--- a/test/config-test.el
+++ b/test/config-test.el
@@ -14,6 +14,29 @@
     (let* ((repo (libgit-repository-open path))
            (config (libgit-repository-config repo))
            (snap (libgit-config-snapshot config)))
+      ;; Can't read from a live config object
       (should-error (libgit-config-get-string config "something") :type 'giterr)
       (should (string= "someone@somewhere.com" (libgit-config-get-string snap "user.email")))
       (should (string= "John Doe" (libgit-config-get-string snap "user.name"))))))
+
+(ert-deftest config-set ()
+  (with-temp-dir path
+    (init)
+    (let* ((repo (libgit-repository-open path))
+           (config (libgit-repository-config repo))
+           trans)
+
+      (libgit-config-set-string config "user.name" "Captain Spiff")
+      (let ((snap (libgit-config-snapshot config)))
+        (should (string= "Captain Spiff" (libgit-config-get-string snap "user.name")))
+        ;; Can't write to a config snapshot
+        (should-error (libgit-config-set-string snap "user.name" "Zorg") :type 'giterr))
+
+      ;; If the config is locked, writes aren't visible immediately
+      (setq trans (libgit-config-lock config))
+      (libgit-config-set-string config "user.name" "Wolfgang Amadeus")
+      (let ((snap (libgit-config-snapshot config)))
+        (should (string= "Captain Spiff" (libgit-config-get-string snap "user.name"))))
+      (libgit-transaction-commit trans)
+      (let ((snap (libgit-config-snapshot config)))
+        (should (string= "Wolfgang Amadeus" (libgit-config-get-string snap "user.name")))))))

--- a/test/config-test.el
+++ b/test/config-test.el
@@ -2,3 +2,18 @@
   (with-temp-dir path
     (init)
     (should (libgit-config-p (libgit-repository-config (libgit-repository-open path))))))
+
+(ert-deftest config-get ()
+  (with-temp-dir path
+    (init)
+    (write ".git/config" "\
+[user]
+  email = someone@somewhere.com
+  name = John Doe
+")
+    (let* ((repo (libgit-repository-open path))
+           (config (libgit-repository-config repo))
+           (snap (libgit-config-snapshot config)))
+      (should-error (libgit-config-get-string config "something") :type 'giterr)
+      (should (string= "someone@somewhere.com" (libgit-config-get-string snap "user.email")))
+      (should (string= "John Doe" (libgit-config-get-string snap "user.name"))))))

--- a/test/config-test.el
+++ b/test/config-test.el
@@ -10,6 +10,10 @@
 [user]
   email = someone@somewhere.com
   name = John Doe
+  age = 7
+  money = 1k
+  hairs = 1m
+  atoms = 1g
 ")
     (let* ((repo (libgit-repository-open path))
            (config (libgit-repository-config repo))
@@ -17,7 +21,11 @@
       ;; Can't read from a live config object
       (should-error (libgit-config-get-string config "something") :type 'giterr)
       (should (string= "someone@somewhere.com" (libgit-config-get-string snap "user.email")))
-      (should (string= "John Doe" (libgit-config-get-string snap "user.name"))))))
+      (should (string= "John Doe" (libgit-config-get-string snap "user.name")))
+      (should (= 7 (libgit-config-get-int snap "user.age")))
+      (should (= 1024 (libgit-config-get-int snap "user.money")))
+      (should (= (* 1024 1024) (libgit-config-get-int snap "user.hairs")))
+      (should (= (* 1024 1024 1024) (libgit-config-get-int snap "user.atoms"))))))
 
 (ert-deftest config-set ()
   (with-temp-dir path
@@ -39,4 +47,8 @@
         (should (string= "Captain Spiff" (libgit-config-get-string snap "user.name"))))
       (libgit-transaction-commit trans)
       (let ((snap (libgit-config-snapshot config)))
-        (should (string= "Wolfgang Amadeus" (libgit-config-get-string snap "user.name")))))))
+        (should (string= "Wolfgang Amadeus" (libgit-config-get-string snap "user.name"))))
+
+      (libgit-config-set-int config "user.age" 7)
+      (let ((snap (libgit-config-snapshot config)))
+        (should (= 7 (libgit-config-get-int snap "user.age")))))))


### PR DESCRIPTION
This was surprisingly involved.

- `libgit-repository-config` opens the config object for a repository. You can use this to **set** values.
- `libgit-config-snapshot` creates a read-only snapshot. You can use this to **get** values.
- `libgit-config-lock` creates a transaction object that you can use to set multiple values atomically. Use `libgit-transaction-free` to release it.