### PR TITLE
Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Probably none of these functions are necessary, since we can expose buffers to E
 - :interrobang: `git-commit-header-field`
 - :heavy_check_mark: `git-commit-id`
 - :heavy_check_mark: `git-commit-lookup`
-- :interrobang: `git-commit-lookup-prefix`
+- :heavy_check_mark: `git-commit-lookup-prefix`
 - :heavy_check_mark: `git-commit-message`
 - :interrobang: `git-commit-message-encoding`
 - :interrobang: `git-commit-message-raw`
@@ -1090,7 +1090,7 @@ Probably none of these functions will be necessary, since we can expose OIDs to 
 - :x: `git-tree-free` (memory management shouldn't be exposed to Emacs)
 - :heavy_check_mark: `git-tree-id`
 - :heavy_check_mark: `git-tree-lookup`
-- :interrobang: `git-tree-lookup-prefix`
+- :heavy_check_mark: `git-tree-lookup-prefix`
 - :heavy_check_mark: `git-tree-owner`
 - :heavy_check_mark: `git-tree-walk`
 

--- a/README.md
+++ b/README.md
@@ -568,8 +568,8 @@ Probably none of these functions will be necessary, since we expose errors to Em
 - :x: `git-object-free` (memory management shouldn't be exposed to Emacs)
 - :heavy_check_mark: `git-object-id`
 - :interrobang: `git-object-lookup`
-- :interrobang: `git-object-lookup-bypath`
-- :interrobang: `git-object-lookup-prefix`
+- :heavy_check_mark: `git-object-lookup-bypath`
+- :heavy_check_mark: `git-object-lookup-prefix`
 - :interrobang: `git-object-owner`
 - :interrobang: `git-object-peel`
 - :heavy_check_mark: `git-object-short-id`

--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ Probably none of these functions will be necessary, since we expose errors to Em
 - :interrobang: `git-object-lookup`
 - :heavy_check_mark: `git-object-lookup-bypath`
 - :heavy_check_mark: `git-object-lookup-prefix`
-- :interrobang: `git-object-owner`
+- :heavy_check_mark: `git-object-owner`
 - :interrobang: `git-object-peel`
 - :heavy_check_mark: `git-object-short-id`
 - :x: `git-object-string2type` (see below)

--- a/README.md
+++ b/README.md
@@ -283,8 +283,8 @@ Probably none of these functions are necessary, since we can expose buffers to E
 - :heavy_check_mark: `git-commit-parentcount`
 - :interrobang: `git-commit-raw-header`
 - :heavy_check_mark: `git-commit-summary`
-- :interrobang: `git-commit-time`
-- :interrobang: `git-commit-time-offset`
+- :heavy_check_mark: `git-commit-time`
+- :x: `git-commit-time-offset` (included in `git-commit-time`)
 - :heavy_check_mark: `git-commit-tree`
 - :heavy_check_mark: `git-commit-tree-id`
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Probably none of these functions are necessary, since we can expose buffers to E
 
 - :interrobang: `git-commit-amend`
 - :heavy_check_mark: `git-commit-author`
-- :interrobang: `git-commit-body`
+- :heavy_check_mark: `git-commit-body`
 - :heavy_check_mark: `git-commit-committer`
 - :interrobang: `git-commit-create`
 - :interrobang: `git-commit-create-buffer`

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ work.
 
 ### Adding a type
 
-Sometimes a struct of type `git_???` may need to be returned to Emacs as an opaque user pointer. 
-To do this, we use a wrapper structure with a type information tag. 
+Sometimes a struct of type `git_???` may need to be returned to Emacs as an opaque user pointer.
+To do this, we use a wrapper structure with a type information tag.
 
 Usually, objects that belong to a repository need to keep the repository alive until after they are
 freed. To do this, we use a hash table with reference counting semantics for repositories to ensure
@@ -145,24 +145,29 @@ a standard include (i.e. `#include "git2.h"`). For now, we will skip those on th
 they are more specialized.
 
 Estimates (updated periodically):
-- Implemented: 74 (9.6%)
-- Should not implement: 82 (10.7%)
-- To do: 611 (79.7%)
-- Total: 767
+- Implemented: 117 (15.1%)
+- Should not implement: 96 (12.4%)
+- To do: 562 (72.5%)
+- Total: 775
 
 ### extra
 
 These are functions that do not have a `libgit2` equivalent.
 
+- :heavy_check_mark: `git-typeof`
 - :heavy_check_mark: `git-blame-p`
+- :heavy_check_mark: `git-commit-p`
 - :heavy_check_mark: `git-object-p`
 - :heavy_check_mark: `git-reference-p`
 - :heavy_check_mark: `git-repository-p`
-- :heavy_check_mark: `git-typeof`
 - :heavy_check_mark: `git-signature-p`
 - :heavy_check_mark: `git-reference-direct-p`
 - :heavy_check_mark: `git-reference-symbolic-p`
-- other type-checking predicates as we add more types
+- :heavy_check_mark: `git-transaction-p`
+- :heavy_check_mark: `git-tree-p`
+- :heavy_check_mark: `git-signature-name`
+- :heavy_check_mark: `git-signature-email`
+- :heavy_check_mark: `git-signature-time`
 
 ### annotated
 
@@ -1054,6 +1059,17 @@ Probably none of these functions will be necessary, since we can expose OIDs to 
 ### trace
 
 - :interrobang: `git-trace-set`
+
+### transaction
+
+- :heavy_check_mark: `git_transaction_commit`
+- :x: `git_transaction_free` (memory management shouldn't be exposed to Emacs)
+- :interrobang: `git_transaction_lock_ref`
+- :interrobang: `git_transaction_new`
+- :interrobang: `git_transaction_remove`
+- :interrobang: `git_transaction_set_reflog`
+- :interrobang: `git_transaction_set_symbolic_target`
+- :interrobang: `git_transaction_set_target`
 
 ### transport
 

--- a/src/egit-commit.c
+++ b/src/egit-commit.c
@@ -62,6 +62,15 @@ emacs_value egit_commit_author(emacs_env *env, emacs_value _commit)
     return egit_wrap(env, EGIT_SIGNATURE, ret);
 }
 
+EGIT_DOC(commit_body, "COMMIT", "Get the message body of COMMIT (everything but the first paragraph).");
+emacs_value egit_commit_body(emacs_env *env, emacs_value _commit)
+{
+    EGIT_ASSERT_COMMIT(_commit);
+    git_commit *commit = EGIT_EXTRACT(_commit);
+    const char *body = git_commit_body(commit);
+    return env->make_string(env, body, strlen(body));
+}
+
 EGIT_DOC(commit_committer, "COMMIT", "Return the committer of COMMIT as a signature object.");
 emacs_value egit_commit_committer(emacs_env *env, emacs_value _commit)
 {

--- a/src/egit-commit.c
+++ b/src/egit-commit.c
@@ -172,6 +172,14 @@ emacs_value egit_commit_summary(emacs_env *env, emacs_value _commit)
     return env->make_string(env, summary, strlen(summary));
 }
 
+EGIT_DOC(commit_time, "COMMIT", "Get the time COMMIT was authored.");
+emacs_value egit_commit_time(emacs_env *env, emacs_value _commit)
+{
+    EGIT_ASSERT_COMMIT(_commit);
+    git_commit *commit = EGIT_EXTRACT(_commit);
+    return em_decode_time(env, git_commit_time(commit), git_commit_time_offset(commit) * 60);
+}
+
 EGIT_DOC(commit_tree, "COMMIT", "Get the tree associated with COMMIT.");
 emacs_value egit_commit_tree(emacs_env *env, emacs_value _commit)
 {

--- a/src/egit-commit.c
+++ b/src/egit-commit.c
@@ -25,6 +25,24 @@ emacs_value egit_commit_lookup(emacs_env *env, emacs_value _repo, emacs_value _o
     return egit_wrap(env, EGIT_COMMIT, commit);
 }
 
+EGIT_DOC(commit_lookup_prefix, "REPO OID", "Lookup a commit in REPO by shortened OID.");
+emacs_value egit_commit_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_value _oid)
+{
+    EGIT_ASSERT_REPOSITORY(_repo);
+    EGIT_ASSERT_STRING(_oid);
+
+    git_repository *repo = EGIT_EXTRACT(_repo);
+    git_oid oid;
+    size_t len;
+    EGIT_EXTRACT_OID_PREFIX(_oid, oid, len);
+
+    git_commit *commit;
+    int retval = git_commit_lookup_prefix(&commit, repo, &oid, len);
+    EGIT_CHECK_ERROR(retval);
+
+    return egit_wrap(env, EGIT_COMMIT, commit);
+}
+
 
 // =============================================================================
 // Getters

--- a/src/egit-commit.h
+++ b/src/egit-commit.h
@@ -4,6 +4,7 @@
 #define EGIT_COMMIT_H
 
 EGIT_DEFUN(commit_lookup, emacs_value _repo, emacs_value _oid);
+EGIT_DEFUN(commit_lookup_prefix, emacs_value _repo, emacs_value _oid);
 
 EGIT_DEFUN(commit_author, emacs_value _commit);
 EGIT_DEFUN(commit_committer, emacs_value _commit);

--- a/src/egit-commit.h
+++ b/src/egit-commit.h
@@ -16,6 +16,7 @@ EGIT_DEFUN(commit_parent, emacs_value _commit, emacs_value _n);
 EGIT_DEFUN(commit_parent_id, emacs_value _commit, emacs_value _n);
 EGIT_DEFUN(commit_parentcount, emacs_value _commit);
 EGIT_DEFUN(commit_summary, emacs_value _commit);
+EGIT_DEFUN(commit_time, emacs_value _commit);
 EGIT_DEFUN(commit_tree, emacs_value _commit);
 EGIT_DEFUN(commit_tree_id, emacs_value _commit);
 

--- a/src/egit-commit.h
+++ b/src/egit-commit.h
@@ -7,6 +7,7 @@ EGIT_DEFUN(commit_lookup, emacs_value _repo, emacs_value _oid);
 EGIT_DEFUN(commit_lookup_prefix, emacs_value _repo, emacs_value _oid);
 
 EGIT_DEFUN(commit_author, emacs_value _commit);
+EGIT_DEFUN(commit_body, emacs_value _body);
 EGIT_DEFUN(commit_committer, emacs_value _commit);
 EGIT_DEFUN(commit_id, emacs_value _commit);
 EGIT_DEFUN(commit_message, emacs_value _commit);

--- a/src/egit-object.c
+++ b/src/egit-object.c
@@ -101,6 +101,15 @@ emacs_value egit_object_id(emacs_env *env, emacs_value _obj)
     return env->make_string(env, oid_s, strlen(oid_s));
 }
 
+EGIT_DOC(object_owner, "OBJECT", "Return the repository that OBJECT belongs to.");
+emacs_value egit_object_owner(emacs_env *env, emacs_value _object)
+{
+    EGIT_ASSERT_OBJECT(_object);
+    git_object *object = EGIT_EXTRACT(_object);
+    git_repository *repo = git_object_owner(object);
+    return egit_wrap_repository(env, repo);
+}
+
 EGIT_DOC(object_short_id, "OBJ", "Return the shortened ID for the given OBJ.");
 emacs_value egit_object_short_id(emacs_env *env, emacs_value _obj)
 {

--- a/src/egit-object.c
+++ b/src/egit-object.c
@@ -6,6 +6,89 @@
 
 
 // =============================================================================
+// Constructors
+
+EGIT_DOC(object_lookup, "REPO OID &optional TYPE",
+         "Look up an object in REPO by OID.\n"
+         "If TYPE is given, error if the object has the wrong type:\n"
+         "  - `blob'\n"
+         "  - `commit'\n"
+         "  - `tag'\n"
+         "  - `tree'");
+emacs_value egit_object_lookup(emacs_env *env, emacs_value _repo, emacs_value _oid, emacs_value _type)
+{
+    EGIT_ASSERT_REPOSITORY(_repo);
+    EGIT_ASSERT_STRING(_oid);
+
+    git_repository *repo = EGIT_EXTRACT(_repo);
+    git_oid oid;
+    EGIT_EXTRACT_OID(_oid, oid);
+
+    git_otype type;
+    if (!EGIT_EXTRACT_BOOLEAN(_type))
+        type = GIT_OBJ_ANY;
+    else if (env->eq(env, _type, em_blob))
+        type = GIT_OBJ_BLOB;
+    else if (env->eq(env, _type, em_commit))
+        type = GIT_OBJ_COMMIT;
+    else if (env->eq(env, _type, em_tag))
+        type = GIT_OBJ_TAG;
+    else if (env->eq(env, _type, em_tree))
+        type = GIT_OBJ_TREE;
+    else {
+        em_signal_wrong_value(env, _type);
+        return em_nil;
+    }
+
+    git_object *object;
+    int retval = git_object_lookup(&object, repo, &oid, type);
+    EGIT_CHECK_ERROR(retval);
+
+    return egit_wrap(env, EGIT_OBJECT, object);
+}
+
+EGIT_DOC(object_lookup_prefix, "REPO OID",
+         "Look up an object in REPO by shortened OID.\n"
+         "If TYPE is given, error if the object has the wrong type:\n"
+         "  - `blob'\n"
+         "  - `commit'\n"
+         "  - `tag'\n"
+         "  - `tree'");
+emacs_value egit_object_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_value _oid, emacs_value _type)
+{
+    EGIT_ASSERT_REPOSITORY(_repo);
+    EGIT_ASSERT_STRING(_oid);
+
+    git_repository *repo = EGIT_EXTRACT(_repo);
+    git_oid oid;
+    size_t len;
+    EGIT_EXTRACT_OID_PREFIX(_oid, oid, len);
+
+    git_otype type;
+    if (!EGIT_EXTRACT_BOOLEAN(_type))
+        type = GIT_OBJ_ANY;
+    else if (env->eq(env, _type, em_blob))
+        type = GIT_OBJ_BLOB;
+    else if (env->eq(env, _type, em_commit))
+        type = GIT_OBJ_COMMIT;
+    else if (env->eq(env, _type, em_tag))
+        type = GIT_OBJ_TAG;
+    else if (env->eq(env, _type, em_tree))
+        type = GIT_OBJ_TREE;
+    else {
+        em_signal_wrong_value(env, _type);
+        return em_nil;
+    }
+
+    git_object *object;
+    int retval = git_object_lookup_prefix(&object, repo, &oid, len, type);
+    EGIT_CHECK_ERROR(retval);
+
+    return egit_wrap(env, EGIT_OBJECT, object);
+}
+
+
+// =============================================================================
 // Getters
 
 EGIT_DOC(object_id, "OBJ", "Return the ID for the given OBJ.");

--- a/src/egit-object.h
+++ b/src/egit-object.h
@@ -3,6 +3,9 @@
 #ifndef EGIT_OBJECT_H
 #define EGIT_OBJECT_H
 
+EGIT_DEFUN(object_lookup, emacs_value _repo, emacs_value _oid, emacs_value _type);
+EGIT_DEFUN(object_lookup_prefix, emacs_value _repo, emacs_value _oid, emacs_value _type);
+
 EGIT_DEFUN(object_id, emacs_value _obj);
 EGIT_DEFUN(object_short_id, emacs_value _obj);
 

--- a/src/egit-object.h
+++ b/src/egit-object.h
@@ -7,6 +7,7 @@ EGIT_DEFUN(object_lookup, emacs_value _repo, emacs_value _oid, emacs_value _type
 EGIT_DEFUN(object_lookup_prefix, emacs_value _repo, emacs_value _oid, emacs_value _type);
 
 EGIT_DEFUN(object_id, emacs_value _obj);
+EGIT_DEFUN(object_owner, emacs_value _obj);
 EGIT_DEFUN(object_short_id, emacs_value _obj);
 
 #endif /* EGIT_OBJECT_H */

--- a/src/egit-signature.c
+++ b/src/egit-signature.c
@@ -33,3 +33,11 @@ emacs_value egit_signature_email(emacs_env *env, emacs_value _sig)
     git_signature *sig = EGIT_EXTRACT(_sig);
     return env->make_string(env, sig->email, strlen(sig->email));
 }
+
+EGIT_DOC(signature_time, "SIGNATURE", "Get the time from SIGNATURE.");
+emacs_value egit_signature_time(emacs_env *env, emacs_value _sig)
+{
+    EGIT_ASSERT_SIGNATURE(_sig);
+    git_signature *sig = EGIT_EXTRACT(_sig);
+    return em_decode_time(env, sig->when.time, sig->when.offset);
+}

--- a/src/egit-signature.c
+++ b/src/egit-signature.c
@@ -39,5 +39,5 @@ emacs_value egit_signature_time(emacs_env *env, emacs_value _sig)
 {
     EGIT_ASSERT_SIGNATURE(_sig);
     git_signature *sig = EGIT_EXTRACT(_sig);
-    return em_decode_time(env, sig->when.time, sig->when.offset);
+    return em_decode_time(env, sig->when.time, sig->when.offset * 60);
 }

--- a/src/egit-signature.h
+++ b/src/egit-signature.h
@@ -7,5 +7,6 @@ EGIT_DEFUN(signature_default, emacs_value _repo);
 
 EGIT_DEFUN(signature_name, emacs_value _sig);
 EGIT_DEFUN(signature_email, emacs_value _sig);
+EGIT_DEFUN(signature_time, emacs_value _sig);
 
 #endif /* EGIT_SIGNATURE_H */

--- a/src/egit-tree.c
+++ b/src/egit-tree.c
@@ -67,6 +67,24 @@ emacs_value egit_tree_lookup(emacs_env *env, emacs_value _repo, emacs_value _oid
     return egit_wrap(env, EGIT_TREE, tree);
 }
 
+EGIT_DOC(tree_lookup_prefix, "REPO OID", "Lookup a tree in REPO by shortened OID.");
+emacs_value egit_tree_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_value _oid)
+{
+    EGIT_ASSERT_REPOSITORY(_repo);
+    EGIT_ASSERT_STRING(_oid);
+
+    git_repository *repo = EGIT_EXTRACT(_repo);
+    git_oid oid;
+    size_t len;
+    EGIT_EXTRACT_OID_PREFIX(_oid, oid, len);
+
+    git_tree *tree;
+    int retval = git_tree_lookup_prefix(&tree, repo, &oid, len);
+    EGIT_CHECK_ERROR(retval);
+
+    return egit_wrap(env, EGIT_TREE, tree);
+}
+
 
 // =============================================================================
 // Getters

--- a/src/egit-tree.h
+++ b/src/egit-tree.h
@@ -4,6 +4,7 @@
 #define EGIT_TREE_H
 
 EGIT_DEFUN(tree_lookup, emacs_value _repo, emacs_value _oid);
+EGIT_DEFUN(tree_lookup_prefix, emacs_value _repo, emacs_value _oid);
 
 EGIT_DEFUN(tree_entry_byid, emacs_value _tree, emacs_value _oid);
 EGIT_DEFUN(tree_entry_byindex, emacs_value _tree, emacs_value _index);

--- a/src/egit.c
+++ b/src/egit.c
@@ -502,6 +502,7 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-signature-default", signature_default, 1, 1);
     DEFUN("libgit-signature-name", signature_name, 1, 1);
     DEFUN("libgit-signature-email", signature_email, 1, 1);
+    DEFUN("libgit-signature-time", signature_time, 1, 1);
 
     // Status
     DEFUN("libgit-status-decode", status_decode, 1, 1);

--- a/src/egit.c
+++ b/src/egit.c
@@ -422,6 +422,9 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-ignore-path-ignored-p", path_ignored_p, 2, 2);
 
     // Object
+    DEFUN("libgit-object-lookup", object_id, 2, 3);
+    DEFUN("libgit-object-lookup-prefix", object_id, 2, 3);
+
     DEFUN("libgit-object-id", object_id, 1, 1);
     DEFUN("libgit-object-short-id", object_short_id, 1, 1);
 

--- a/src/egit.c
+++ b/src/egit.c
@@ -386,6 +386,7 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-commit-lookup-prefix", commit_lookup_prefix, 2, 2);
 
     DEFUN("libgit-commit-author", commit_author, 1, 1);
+    DEFUN("libgit-commit-body", commit_body, 1, 1);
     DEFUN("libgit-commit-committer", commit_committer, 1, 1);
     DEFUN("libgit-commit-id", commit_id, 1, 1);
     DEFUN("libgit-commit-message", commit_message, 1, 1);

--- a/src/egit.c
+++ b/src/egit.c
@@ -383,6 +383,7 @@ void egit_init(emacs_env *env)
 
     // Commit
     DEFUN("libgit-commit-lookup", commit_lookup, 2, 2);
+    DEFUN("libgit-commit-lookup-prefix", commit_lookup_prefix, 2, 2);
 
     DEFUN("libgit-commit-author", commit_author, 1, 1);
     DEFUN("libgit-commit-committer", commit_committer, 1, 1);
@@ -509,6 +510,7 @@ void egit_init(emacs_env *env)
 
     // Tree
     DEFUN("libgit-tree-lookup", tree_lookup, 2, 2);
+    DEFUN("libgit-tree-lookup-prefix", tree_lookup_prefix, 2, 2);
 
     DEFUN("libgit-tree-entry-byid", tree_entry_byid, 2, 2);
     DEFUN("libgit-tree-entry-byindex", tree_entry_byindex, 2, 2);

--- a/src/egit.c
+++ b/src/egit.c
@@ -426,6 +426,7 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-object-lookup-prefix", object_id, 2, 3);
 
     DEFUN("libgit-object-id", object_id, 1, 1);
+    DEFUN("libgit-object-owner", object_owner, 1, 1);
     DEFUN("libgit-object-short-id", object_short_id, 1, 1);
 
     // Reference

--- a/src/egit.c
+++ b/src/egit.c
@@ -395,6 +395,7 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-commit-parent-id", commit_parent_id, 1, 2);
     DEFUN("libgit-commit-parentcount", commit_parentcount, 1, 1);
     DEFUN("libgit-commit-summary", commit_summary, 1, 1);
+    DEFUN("libgit-commit-time", commit_time, 1, 1);
     DEFUN("libgit-commit-tree", commit_tree, 1, 1);
     DEFUN("libgit-commit-tree-id", commit_tree_id, 1, 1);
 

--- a/src/egit.h
+++ b/src/egit.h
@@ -193,6 +193,19 @@
     } while (0)
 
 /**
+ * Extract a partial git_oid from an emacs_value and store its length.
+ * Caller is responsible for ensuring that the emacs_value is a string.
+ */
+#define EGIT_EXTRACT_OID_PREFIX(val, tgt, tgt_len)      \
+    do {                                                \
+        char *__str = em_get_string(env, (val));        \
+        tgt_len = strlen(__str);                        \
+        int __retval = git_oid_fromstrp(&(tgt), __str); \
+        free(__str);                                    \
+        EGIT_CHECK_ERROR(__retval);                     \
+    } while (0)
+
+/**
  * If libgit2 signalled an error, pass the error on to Emacs and return.
  * @param val A libgit2 return value (negative value indicates error).
  */

--- a/src/interface.c
+++ b/src/interface.c
@@ -72,7 +72,7 @@ emacs_value em_pre, em_post, em_skip;
 static emacs_value _cons, _defalias, _define_error, _expand_file_name, _giterr,
     _not_implemented, _provide, _user_ptrp, _vector, _wrong_type_argument,
     _wrong_value_argument, _consp, _car, _cdr, _list, _listp, _length, _symbol_value,
-    _default_directory, _assq, _args_out_of_range;
+    _default_directory, _assq, _args_out_of_range, _decode_time;
 
 
 void em_init(emacs_env *env)
@@ -196,6 +196,7 @@ void em_init(emacs_env *env)
     _consp = GLOBREF(INTERN("consp"));
     _car = GLOBREF(INTERN("car"));
     _cdr = GLOBREF(INTERN("cdr"));
+    _decode_time = GLOBREF(INTERN("decode-time"));
     _default_directory = GLOBREF(INTERN("default-directory"));
     _list = GLOBREF(INTERN("list"));
     _listp = GLOBREF(INTERN("listp"));
@@ -359,4 +360,11 @@ char *em_default_directory(emacs_env *env)
     emacs_value dir = em_funcall(env, _symbol_value, 1, _default_directory);
     dir = em_expand_file_name(env, dir);
     return em_get_string(env, dir);
+}
+
+emacs_value em_decode_time(emacs_env *env, intmax_t timestamp, intmax_t offset)
+{
+    return em_funcall(env, _decode_time, 2,
+                      env->make_integer(env, timestamp),
+                      env->make_integer(env, offset));
 }

--- a/src/interface.h
+++ b/src/interface.h
@@ -224,4 +224,9 @@ bool em_user_ptrp(emacs_env *env, emacs_value val);
  */
 char *em_default_directory(emacs_env *env);
 
+/**
+ * Run (decode-time TIMESTAMP OFFSET) in Emacs.
+ */
+emacs_value em_decode_time(emacs_env *env, intmax_t timestamp, intmax_t offset);
+
 #endif /* INTERFACE_H */

--- a/test/commit-test.el
+++ b/test/commit-test.el
@@ -88,4 +88,5 @@
     (let* ((repo (libgit-repository-open path))
            (id (libgit-reference-name-to-id repo "HEAD"))
            (commit (libgit-commit-lookup repo id)))
-      (should (string= "here is a message!" (libgit-commit-summary commit))))))
+      (should (string= "here is a message!" (libgit-commit-summary commit)))
+      (should (string= "here is some more info" (libgit-commit-body commit))))))

--- a/test/commit-test.el
+++ b/test/commit-test.el
@@ -4,9 +4,11 @@
     (commit-change "test" "content")
     (let* ((repo (libgit-repository-open path))
            (id (libgit-reference-name-to-id repo "HEAD"))
-           (commit (libgit-commit-lookup repo id)))
+           (commit (libgit-commit-lookup repo id))
+           (commit-short (libgit-commit-lookup-prefix repo (substring id 0 7))))
       (should (libgit-commit-p commit))
       (should (string= id (libgit-commit-id commit)))
+      (should (string= id (libgit-commit-id commit-short)))
       (should-error (libgit-commit-lookup repo "test") :type 'giterr))))
 
 (ert-deftest commit-parentcount ()


### PR DESCRIPTION
- Functions for looking up objects based on short IDs
- Generic object lookup (in addition specific ones for commit, tree, etc.)
- Get time of commits and signatures in standard Emacs form
- `libgit-commit-body` was missing from earlier