### PR TITLE
status: remove prefixes from symbols

### DIFF
--- a/src/egit-status.c
+++ b/src/egit-status.c
@@ -31,7 +31,7 @@ emacs_value egit_status_decode(emacs_env *env, emacs_value status)
 #define CHECK(name, symbol)                             \
     do {                                                \
         if (flags & GIT_STATUS_##name) {                \
-            statuses[nstatuses++] = em_fs_##symbol;     \
+            statuses[nstatuses++] = em_##symbol;        \
         }                                               \
     } while (false)
 
@@ -112,13 +112,13 @@ emacs_value egit_status_should_ignore_p(emacs_env *env, emacs_value _repo,
 bool convert_show_option(git_status_show_t *out, emacs_env *env,
                          emacs_value arg)
 {
-    if (env->eq(env, arg, em_status_show_index_only)) {
+    if (env->eq(env, arg, em_index_only)) {
         *out = GIT_STATUS_SHOW_INDEX_ONLY;
         return true;
-    } else if (env->eq(env, arg, em_status_show_workdir_only)) {
+    } else if (env->eq(env, arg, em_workdir_only)) {
         *out = GIT_STATUS_SHOW_WORKDIR_ONLY;
         return true;
-    } else if (env->eq(env, arg, em_status_show_index_and_workdir)) {
+    } else if (env->eq(env, arg, em_index_and_workdir)) {
         *out = GIT_STATUS_SHOW_INDEX_AND_WORKDIR;
         return true;
     } else if (env->is_not_nil(env, arg)) {
@@ -149,7 +149,7 @@ bool convert_flags_option(git_status_opt_t *out, emacs_env *env,
         arg = em_cdr(env, arg);
 
 #define CHECK(symbol, enum)                                     \
-        if (env->eq(env, flag, em_status_opt_##symbol)) {       \
+        if (env->eq(env, flag, em_##symbol)) {                  \
             *out |= GIT_STATUS_OPT_##enum;                      \
             continue;                                           \
         }

--- a/src/interface.c
+++ b/src/interface.c
@@ -29,25 +29,20 @@ emacs_value em_merge, em_revert, em_revert_sequence, em_cherrypick,
 emacs_value em_direct, em_symbolic;
 
 // File statuses
-emacs_value em_fs_index_new, em_fs_index_modified, em_fs_index_deleted,
-    em_fs_index_renamed, em_fs_index_typechange, em_fs_wt_new,
-    em_fs_wt_modified, em_fs_wt_deleted, em_fs_wt_typechange, em_fs_wt_renamed,
-    em_fs_wt_unreadable, em_fs_ignored, em_fs_conflicted;
+emacs_value em_index_new, em_index_modified, em_index_deleted,
+    em_index_renamed, em_index_typechange, em_wt_new,
+    em_wt_modified, em_wt_deleted, em_wt_typechange, em_wt_renamed,
+    em_wt_unreadable, em_ignored, em_conflicted;
 
 // Symbols for enum git_status_show_t
-emacs_value em_status_show_index_only, em_status_show_workdir_only,
-    em_status_show_index_and_workdir;
+emacs_value em_index_only, em_workdir_only, em_index_and_workdir;
 
 // Symbols for enum git_status_opt_t
-emacs_value em_status_opt_include_untracked, em_status_opt_include_ignored,
-    em_status_opt_include_unmodified, em_status_opt_exclude_submodules,
-    em_status_opt_recurse_untracked_dirs, em_status_opt_disable_pathspec_match,
-    em_status_opt_recurse_ignored_dirs, em_status_opt_renames_head_to_index,
-    em_status_opt_renames_index_to_workdir, em_status_opt_sort_case_sensitively,
-    em_status_opt_sort_case_insensitively, em_status_opt_renames_from_rewrites,
-    em_status_opt_no_refresh, em_status_opt_update_index,
-    em_status_opt_include_unreadable,
-    em_status_opt_include_unreadable_as_untracked;
+emacs_value em_include_untracked, em_include_ignored, em_include_unmodified, em_exclude_submodules,
+    em_recurse_untracked_dirs, em_disable_pathspec_match, em_recurse_ignored_dirs,
+    em_renames_head_to_index, em_renames_index_to_workdir, em_sort_case_sensitively,
+    em_sort_case_insensitively, em_renames_from_rewrites, em_no_refresh, em_update_index,
+    em_include_unreadable, em_include_unreadable_as_untracked;
 
 // Blame hunk properties
 emacs_value em_lines_in_hunk,
@@ -131,49 +126,40 @@ void em_init(emacs_env *env)
     em_direct = GLOBREF(INTERN("direct"));
     em_symbolic = GLOBREF(INTERN("symbolic"));
 
-    em_fs_index_new = GLOBREF(INTERN("index-new"));
-    em_fs_index_modified = GLOBREF(INTERN("index-modified"));
-    em_fs_index_deleted = GLOBREF(INTERN("index-deleted"));
-    em_fs_index_renamed = GLOBREF(INTERN("index-renamed"));
-    em_fs_index_typechange = GLOBREF(INTERN("index-typechange"));
-    em_fs_wt_new = GLOBREF(INTERN("wt-new"));
-    em_fs_wt_modified = GLOBREF(INTERN("wt-modified"));
-    em_fs_wt_deleted = GLOBREF(INTERN("wt-deleted"));
-    em_fs_wt_typechange = GLOBREF(INTERN("wt-typechange"));
-    em_fs_wt_renamed = GLOBREF(INTERN("wt-renamed"));
-    em_fs_wt_unreadable = GLOBREF(INTERN("wt-unreadable"));
-    em_fs_ignored = GLOBREF(INTERN("ignored"));
-    em_fs_conflicted = GLOBREF(INTERN("conflicted"));
+    em_index_new = GLOBREF(INTERN("index-new"));
+    em_index_modified = GLOBREF(INTERN("index-modified"));
+    em_index_deleted = GLOBREF(INTERN("index-deleted"));
+    em_index_renamed = GLOBREF(INTERN("index-renamed"));
+    em_index_typechange = GLOBREF(INTERN("index-typechange"));
+    em_wt_new = GLOBREF(INTERN("wt-new"));
+    em_wt_modified = GLOBREF(INTERN("wt-modified"));
+    em_wt_deleted = GLOBREF(INTERN("wt-deleted"));
+    em_wt_typechange = GLOBREF(INTERN("wt-typechange"));
+    em_wt_renamed = GLOBREF(INTERN("wt-renamed"));
+    em_wt_unreadable = GLOBREF(INTERN("wt-unreadable"));
+    em_ignored = GLOBREF(INTERN("ignored"));
+    em_conflicted = GLOBREF(INTERN("conflicted"));
 
-    em_status_show_index_only = GLOBREF(INTERN("index-only"));
-    em_status_show_workdir_only = GLOBREF(INTERN("workdir-only"));
-    em_status_show_index_and_workdir = GLOBREF(INTERN("index-and-workdir"));
+    em_index_only = GLOBREF(INTERN("index-only"));
+    em_workdir_only = GLOBREF(INTERN("workdir-only"));
+    em_index_and_workdir = GLOBREF(INTERN("index-and-workdir"));
 
-    em_status_opt_include_untracked = GLOBREF(INTERN("include-untracked"));
-    em_status_opt_include_ignored = GLOBREF(INTERN("include-ignored"));
-    em_status_opt_include_unmodified = GLOBREF(INTERN("include-unmodified"));
-    em_status_opt_exclude_submodules = GLOBREF(INTERN("exclude-submodules"));
-    em_status_opt_recurse_untracked_dirs =
-        GLOBREF(INTERN("recurse-untracked-dirs"));
-    em_status_opt_disable_pathspec_match =
-        GLOBREF(INTERN("disable-pathspec-match"));
-    em_status_opt_recurse_ignored_dirs =
-        GLOBREF(INTERN("recurse-ignored-dirs"));
-    em_status_opt_renames_head_to_index =
-        GLOBREF(INTERN("renames-head-to-index"));
-    em_status_opt_renames_index_to_workdir =
-        GLOBREF(INTERN("renames-index-to-workdir"));
-    em_status_opt_sort_case_sensitively =
-        GLOBREF(INTERN("sort-case-sensitively"));
-    em_status_opt_sort_case_insensitively =
-        GLOBREF(INTERN("sort-case-insensitively"));
-    em_status_opt_renames_from_rewrites =
-        GLOBREF(INTERN("renames-from-rewrites"));
-    em_status_opt_no_refresh = GLOBREF(INTERN("no-refresh"));
-    em_status_opt_update_index = GLOBREF(INTERN("update-index"));
-    em_status_opt_include_unreadable = GLOBREF(INTERN("include-unreadable"));
-    em_status_opt_include_unreadable_as_untracked =
-        GLOBREF(INTERN("include-unreadable-as-untracked"));
+    em_include_untracked = GLOBREF(INTERN("include-untracked"));
+    em_include_ignored = GLOBREF(INTERN("include-ignored"));
+    em_include_unmodified = GLOBREF(INTERN("include-unmodified"));
+    em_exclude_submodules = GLOBREF(INTERN("exclude-submodules"));
+    em_recurse_untracked_dirs = GLOBREF(INTERN("recurse-untracked-dirs"));
+    em_disable_pathspec_match = GLOBREF(INTERN("disable-pathspec-match"));
+    em_recurse_ignored_dirs = GLOBREF(INTERN("recurse-ignored-dirs"));
+    em_renames_head_to_index = GLOBREF(INTERN("renames-head-to-index"));
+    em_renames_index_to_workdir = GLOBREF(INTERN("renames-index-to-workdir"));
+    em_sort_case_sensitively = GLOBREF(INTERN("sort-case-sensitively"));
+    em_sort_case_insensitively = GLOBREF(INTERN("sort-case-insensitively"));
+    em_renames_from_rewrites = GLOBREF(INTERN("renames-from-rewrites"));
+    em_no_refresh = GLOBREF(INTERN("no-refresh"));
+    em_update_index = GLOBREF(INTERN("update-index"));
+    em_include_unreadable = GLOBREF(INTERN("include-unreadable"));
+    em_include_unreadable_as_untracked = GLOBREF(INTERN("include-unreadable-as-untracked"));
 
     em_lines_in_hunk = GLOBREF(INTERN("lines-in-hunk"));
     em_final_commit_id = GLOBREF(INTERN("final-commit-id"));

--- a/src/interface.h
+++ b/src/interface.h
@@ -23,25 +23,20 @@ extern emacs_value em_merge, em_revert, em_revert_sequence, em_cherrypick,
 extern emacs_value em_direct, em_symbolic;
 
 // File statuses
-extern emacs_value em_fs_index_new, em_fs_index_modified, em_fs_index_deleted,
-    em_fs_index_renamed, em_fs_index_typechange, em_fs_wt_new,
-    em_fs_wt_modified, em_fs_wt_deleted, em_fs_wt_typechange, em_fs_wt_renamed,
-    em_fs_wt_unreadable, em_fs_ignored, em_fs_conflicted;
+extern emacs_value em_index_new, em_index_modified, em_index_deleted,
+    em_index_renamed, em_index_typechange, em_wt_new,
+    em_wt_modified, em_wt_deleted, em_wt_typechange, em_wt_renamed,
+    em_wt_unreadable, em_ignored, em_conflicted;
 
 // Symbols for enum git_status_show_t
-extern emacs_value em_status_show_index_only, em_status_show_workdir_only,
-    em_status_show_index_and_workdir;
+extern emacs_value em_index_only, em_workdir_only, em_index_and_workdir;
 
 // Symbols for enum git_status_opt_t
-extern emacs_value em_status_opt_include_untracked,
-    em_status_opt_include_ignored, em_status_opt_include_unmodified,
-    em_status_opt_exclude_submodules, em_status_opt_recurse_untracked_dirs,
-    em_status_opt_disable_pathspec_match, em_status_opt_recurse_ignored_dirs,
-    em_status_opt_renames_head_to_index, em_status_opt_renames_index_to_workdir,
-    em_status_opt_sort_case_sensitively, em_status_opt_sort_case_insensitively,
-    em_status_opt_renames_from_rewrites, em_status_opt_no_refresh,
-    em_status_opt_update_index, em_status_opt_include_unreadable,
-    em_status_opt_include_unreadable_as_untracked;
+extern emacs_value em_include_untracked, em_include_ignored, em_include_unmodified,
+    em_exclude_submodules, em_recurse_untracked_dirs, em_disable_pathspec_match,
+    em_recurse_ignored_dirs, em_renames_head_to_index, em_renames_index_to_workdir,
+    em_sort_case_sensitively, em_sort_case_insensitively, em_renames_from_rewrites, em_no_refresh,
+    em_update_index, em_include_unreadable, em_include_unreadable_as_untracked;
 
 // Blame hunk properties
 extern emacs_value em_lines_in_hunk,


### PR DESCRIPTION
In other words, make sure that `em_xxxx` is always the symbol `xxxx` (with underscores replaced by hyphens). This is the usual convention, and many of these symbols are useful in other parts of libgit2, so it doesn't make sense to namespace them like this. I'm working on diffing now and I need some of these there.