### PR TITLE
Unified memory management

### DIFF
--- a/src/egit-clone.c
+++ b/src/egit-clone.c
@@ -23,5 +23,5 @@ emacs_value egit_clone(emacs_env *env, emacs_value _url, emacs_value _path)
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }

--- a/src/egit-commit.c
+++ b/src/egit-commit.c
@@ -127,7 +127,7 @@ emacs_value egit_commit_owner(emacs_env *env, emacs_value _commit)
     EGIT_ASSERT_COMMIT(_commit);
     git_commit *commit = EGIT_EXTRACT(_commit);
     git_repository *repo = git_commit_owner(commit);
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 EGIT_DOC(commit_parent, "COMMIT &optional N", "Return the Nth parent of COMMIT.");

--- a/src/egit-index.c
+++ b/src/egit-index.c
@@ -216,7 +216,7 @@ emacs_value egit_index_owner(emacs_env *env, emacs_value _index)
     EGIT_ASSERT_INDEX(_index);
     git_index *index = EGIT_EXTRACT(_index);
     git_repository *repo = git_index_owner(index);
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 EGIT_DOC(index_path, "INDEX", "Get the path to the index file on disk.");

--- a/src/egit-object.c
+++ b/src/egit-object.c
@@ -107,7 +107,7 @@ emacs_value egit_object_owner(emacs_env *env, emacs_value _object)
     EGIT_ASSERT_OBJECT(_object);
     git_object *object = EGIT_EXTRACT(_object);
     git_repository *repo = git_object_owner(object);
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 EGIT_DOC(object_short_id, "OBJ", "Return the shortened ID for the given OBJ.");

--- a/src/egit-reference.c
+++ b/src/egit-reference.c
@@ -183,7 +183,7 @@ emacs_value egit_reference_owner(emacs_env *env, emacs_value _ref)
     EGIT_ASSERT_REFERENCE(_ref);
     git_reference *ref = EGIT_EXTRACT(_ref);
     git_repository *repo = git_reference_owner(ref);
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 EGIT_DOC(reference_peel, "REF &optional TYPE",

--- a/src/egit-repository.c
+++ b/src/egit-repository.c
@@ -28,7 +28,7 @@ emacs_value egit_repository_init(emacs_env *env, emacs_value _path, emacs_value 
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 EGIT_DOC(repository_open, "PATH", "Open an existing repository at PATH.");
@@ -46,7 +46,7 @@ emacs_value egit_repository_open(emacs_env *env, emacs_value _path)
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 EGIT_DOC(repository_open_bare, "PATH",
@@ -66,7 +66,7 @@ emacs_value egit_repository_open_bare(emacs_env *env, emacs_value _path)
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 

--- a/src/egit-tree.c
+++ b/src/egit-tree.c
@@ -195,7 +195,7 @@ emacs_value egit_tree_owner(emacs_env *env, emacs_value _tree)
     EGIT_ASSERT_TREE(_tree);
     git_tree *tree = EGIT_EXTRACT(_tree);
     git_repository *repo = git_tree_owner(tree);
-    return egit_wrap_repository(env, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo);
 }
 
 

--- a/src/egit.h
+++ b/src/egit.h
@@ -323,30 +323,7 @@ bool egit_assert_type(emacs_env *env, emacs_value obj, egit_type type, emacs_val
 bool egit_assert_object(emacs_env *env, emacs_value obj);
 
 /**
- * Decrease the reference count of a git_repository struct.
- * This may cause the object to be freed.
- */
-void egit_decref_repository(git_repository *wrapped);
-
-/**
- * Decrease the reference count of a egit_object struct that wraps a git_repository.
- * This will fail if the wrapper wraps something of another type.
- * This may cause the object to be freed.
- * This function is suitable to use as a finalizer for Emacs user pointers.
- */
-void egit_decref_repository_wrapper(void *wrapper);
-
-/**
- * Wrap a git_repository structure in an emacs_value, adding it to the object store if necessary.
- * @param env The active Emacs environment.
- * @param ptr The pointer to store.
- * @return The Emacs value.
- */
-emacs_value egit_wrap_repository(emacs_env *env, git_repository* ptr);
-
-/**
  * Wrap a git_??? structure in an emacs_value.
- * NOTE: Use egit_wrap_repository instead of this one for repositories.
  * @param env The active Emacs environment.
  * @param obj The type of the object.
  * @param ptr The pointer to store.


### PR DESCRIPTION
This removes the special-casing of repositories. That is to say, they are still treated specially, but only because they are a "reference-counted" type. Right now it is the only one, but we're going to have to do this with diffs too, because the callback system there involves making a lot of emacs pointers to the same diff structure. So I figured I'd bring this in now so that I can just add `EGIT_DIFF` as another type getting the same treatment as `EGIT_REPOSITORY` later.