### PR TITLE
Keep explicit parent pointer

### DIFF
--- a/src/egit-blame.c
+++ b/src/egit-blame.c
@@ -79,7 +79,7 @@ emacs_value egit_blame_file(emacs_env *env, emacs_value _repo, emacs_value _path
     free(path);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_BLAME, blame);
+    return egit_wrap(env, EGIT_BLAME, blame, NULL);
 }
 
 static

--- a/src/egit-blame.c
+++ b/src/egit-blame.c
@@ -58,7 +58,7 @@ EGIT_DOC(blame_file, "REPOSITORY PATH &optional OPTIONS",
 emacs_value egit_blame_file(emacs_env *env, emacs_value _repo, emacs_value _path, emacs_value _options)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_path);
+    EM_ASSERT_STRING(_path);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
 
@@ -72,7 +72,7 @@ emacs_value egit_blame_file(emacs_env *env, emacs_value _repo, emacs_value _path
         }
     }
 
-    char *path = EGIT_EXTRACT_STRING(_path);
+    char *path = EM_EXTRACT_STRING(_path);
 
     git_blame *blame = NULL;
     retval = git_blame_file(&blame, repo, path, &opts);

--- a/src/egit-branch.c
+++ b/src/egit-branch.c
@@ -46,7 +46,7 @@ emacs_value egit_branch_create(emacs_env *env, emacs_value _repo, emacs_value _n
     git_commit_free(commit);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 EGIT_DOC(branch_create_from_annotated, "REPO NAME COMMITISH FORCE",
@@ -94,7 +94,7 @@ emacs_value egit_branch_create_from_annotated(
     git_annotated_commit_free(commit);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 EGIT_DOC(branch_lookup, "REPO NAME &optional REMOTE",
@@ -116,7 +116,7 @@ emacs_value egit_branch_lookup(emacs_env *env, emacs_value _repo, emacs_value _n
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, target_ref);
+    return egit_wrap(env, EGIT_REFERENCE, target_ref, NULL);
 }
 
 EGIT_DOC(branch_delete, "REF", "Delete branch at REF.");

--- a/src/egit-branch.c
+++ b/src/egit-branch.c
@@ -8,15 +8,15 @@ EGIT_DOC(branch_create, "REPO NAME COMMITISH FORCE",
 emacs_value egit_branch_create(emacs_env *env, emacs_value _repo, emacs_value _name, emacs_value _commitish, emacs_value _force)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_commitish);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_commitish);
+    EM_ASSERT_STRING(_name);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     
     git_reference *target_ref;
     int retval;
     {
-        char *commitish = EGIT_EXTRACT_STRING(_commitish);
+        char *commitish = EM_EXTRACT_STRING(_commitish);
         retval = git_reference_dwim(&target_ref, repo, commitish);
         free(commitish);
     }
@@ -38,8 +38,8 @@ emacs_value egit_branch_create(emacs_env *env, emacs_value _repo, emacs_value _n
 
     git_reference *ref;
     {
-        char *name = EGIT_EXTRACT_STRING(_name);
-        bool force = EGIT_EXTRACT_BOOLEAN(_force);
+        char *name = EM_EXTRACT_STRING(_name);
+        bool force = EM_EXTRACT_BOOLEAN(_force);
         retval = git_branch_create(&ref, repo, name, commit, force);
         free(name);
     }
@@ -56,15 +56,15 @@ emacs_value egit_branch_create_from_annotated(
     emacs_env *env, emacs_value _repo, emacs_value _name, emacs_value _commitish, emacs_value _force)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_commitish);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_commitish);
+    EM_ASSERT_STRING(_name);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     
     git_reference *target_ref;
     int retval;
     {
-        char *commitish = EGIT_EXTRACT_STRING(_commitish);
+        char *commitish = EM_EXTRACT_STRING(_commitish);
         retval = git_reference_dwim(&target_ref, repo, commitish);
         free(commitish);
     }
@@ -86,8 +86,8 @@ emacs_value egit_branch_create_from_annotated(
 
     git_reference *ref;
     {
-        char *name = EGIT_EXTRACT_STRING(_name);
-        bool force = EGIT_EXTRACT_BOOLEAN(_force);
+        char *name = EM_EXTRACT_STRING(_name);
+        bool force = EM_EXTRACT_BOOLEAN(_force);
         retval = git_branch_create_from_annotated(&ref, repo, name, commit, force);
         free(name);
     }
@@ -102,15 +102,15 @@ EGIT_DOC(branch_lookup, "REPO NAME &optional REMOTE",
 emacs_value egit_branch_lookup(emacs_env *env, emacs_value _repo, emacs_value _name, emacs_value _remote)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
 
     git_reference *target_ref;
     int retval;
     {
-        char *branch = EGIT_EXTRACT_STRING(_name);
-        int remote = EGIT_EXTRACT_BOOLEAN(_remote);
+        char *branch = EM_EXTRACT_STRING(_name);
+        int remote = EM_EXTRACT_BOOLEAN(_remote);
         retval = git_branch_lookup(&target_ref, repo, branch, remote ? GIT_BRANCH_REMOTE : GIT_BRANCH_LOCAL);
         free(branch);
     }

--- a/src/egit-clone.c
+++ b/src/egit-clone.c
@@ -23,5 +23,5 @@ emacs_value egit_clone(emacs_env *env, emacs_value _url, emacs_value _path)
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }

--- a/src/egit-clone.c
+++ b/src/egit-clone.c
@@ -8,15 +8,15 @@
 EGIT_DOC(clone, "URL PATH", "Clone the repository at URL to PATH and return it.");
 emacs_value egit_clone(emacs_env *env, emacs_value _url, emacs_value _path)
 {
-    EGIT_ASSERT_STRING(_url);
-    EGIT_ASSERT_STRING(_path);
-    EGIT_NORMALIZE_PATH(_path);
+    EM_ASSERT_STRING(_url);
+    EM_ASSERT_STRING(_path);
+    EM_NORMALIZE_PATH(_path);
 
     git_repository *repo;
     int retval;
     {
-        char *url = EGIT_EXTRACT_STRING(_url);
-        char *path = EGIT_EXTRACT_STRING(_path);
+        char *url = EM_EXTRACT_STRING(_url);
+        char *path = EM_EXTRACT_STRING(_path);
         retval = git_clone(&repo, url, path, NULL);
         free(url);
         free(path);

--- a/src/egit-commit.c
+++ b/src/egit-commit.c
@@ -12,7 +12,7 @@ EGIT_DOC(commit_lookup, "REPO OID", "Look up a commit in REPO by OID.");
 emacs_value egit_commit_lookup(emacs_env *env, emacs_value _repo, emacs_value _oid)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_oid);
+    EM_ASSERT_STRING(_oid);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid oid;
@@ -29,7 +29,7 @@ EGIT_DOC(commit_lookup_prefix, "REPO OID", "Lookup a commit in REPO by shortened
 emacs_value egit_commit_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_value _oid)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_oid);
+    EM_ASSERT_STRING(_oid);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid oid;
@@ -110,9 +110,9 @@ EGIT_DOC(commit_nth_gen_ancestor, "COMMIT N",
 emacs_value egit_commit_nth_gen_ancestor(emacs_env *env, emacs_value _commit, emacs_value _n)
 {
     EGIT_ASSERT_COMMIT(_commit);
-    EGIT_ASSERT_INTEGER(_n);
+    EM_ASSERT_INTEGER(_n);
     git_commit *commit = EGIT_EXTRACT(_commit);
-    intmax_t n = EGIT_EXTRACT_INTEGER(_n);
+    intmax_t n = EM_EXTRACT_INTEGER(_n);
 
     git_commit *ret;
     int retval = git_commit_nth_gen_ancestor(&ret, commit, n);
@@ -134,9 +134,9 @@ EGIT_DOC(commit_parent, "COMMIT &optional N", "Return the Nth parent of COMMIT."
 emacs_value egit_commit_parent(emacs_env *env, emacs_value _commit, emacs_value _n)
 {
     EGIT_ASSERT_COMMIT(_commit);
-    EGIT_ASSERT_INTEGER_OR_NIL(_n);
+    EM_ASSERT_INTEGER_OR_NIL(_n);
     git_commit *commit = EGIT_EXTRACT(_commit);
-    intmax_t n = EGIT_EXTRACT_INTEGER_OR_DEFAULT(_n, 0);
+    intmax_t n = EM_EXTRACT_INTEGER_OR_DEFAULT(_n, 0);
 
     git_commit *ret;
     int retval = git_commit_parent(&ret, commit, n);
@@ -149,9 +149,9 @@ EGIT_DOC(commit_parent_id, "COMMIT &optional N", "Return the ID of the Nth paren
 emacs_value egit_commit_parent_id(emacs_env *env, emacs_value _commit, emacs_value _n)
 {
     EGIT_ASSERT_COMMIT(_commit);
-    EGIT_ASSERT_INTEGER_OR_NIL(_n);
+    EM_ASSERT_INTEGER_OR_NIL(_n);
     git_commit *commit = EGIT_EXTRACT(_commit);
-    intmax_t n = EGIT_EXTRACT_INTEGER_OR_DEFAULT(_n, 0);
+    intmax_t n = EM_EXTRACT_INTEGER_OR_DEFAULT(_n, 0);
 
     const git_oid *oid = git_commit_parent_id(commit, n);
     if (!oid) {

--- a/src/egit-commit.c
+++ b/src/egit-commit.c
@@ -22,7 +22,7 @@ emacs_value egit_commit_lookup(emacs_env *env, emacs_value _repo, emacs_value _o
     int retval = git_commit_lookup(&commit, repo, &oid);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_COMMIT, commit);
+    return egit_wrap(env, EGIT_COMMIT, commit, NULL);
 }
 
 EGIT_DOC(commit_lookup_prefix, "REPO OID", "Lookup a commit in REPO by shortened OID.");
@@ -40,7 +40,7 @@ emacs_value egit_commit_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_v
     int retval = git_commit_lookup_prefix(&commit, repo, &oid, len);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_COMMIT, commit);
+    return egit_wrap(env, EGIT_COMMIT, commit, NULL);
 }
 
 
@@ -59,7 +59,7 @@ emacs_value egit_commit_author(emacs_env *env, emacs_value _commit)
     int retval = git_signature_dup(&ret, sig);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_SIGNATURE, ret);
+    return egit_wrap(env, EGIT_SIGNATURE, ret, NULL);
 }
 
 EGIT_DOC(commit_body, "COMMIT", "Get the message body of COMMIT (everything but the first paragraph).");
@@ -83,7 +83,7 @@ emacs_value egit_commit_committer(emacs_env *env, emacs_value _commit)
     int retval = git_signature_dup(&ret, sig);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_SIGNATURE, ret);
+    return egit_wrap(env, EGIT_SIGNATURE, ret, NULL);
 }
 
 EGIT_DOC(commit_id, "COMMIT", "Return the ID of COMMIT.");
@@ -118,7 +118,7 @@ emacs_value egit_commit_nth_gen_ancestor(emacs_env *env, emacs_value _commit, em
     int retval = git_commit_nth_gen_ancestor(&ret, commit, n);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_COMMIT, ret);
+    return egit_wrap(env, EGIT_COMMIT, ret, NULL);
 }
 
 EGIT_DOC(commit_owner, "COMMIT", "Return the repository that COMMIT belongs to.");
@@ -127,7 +127,7 @@ emacs_value egit_commit_owner(emacs_env *env, emacs_value _commit)
     EGIT_ASSERT_COMMIT(_commit);
     git_commit *commit = EGIT_EXTRACT(_commit);
     git_repository *repo = git_commit_owner(commit);
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 EGIT_DOC(commit_parent, "COMMIT &optional N", "Return the Nth parent of COMMIT.");
@@ -142,7 +142,7 @@ emacs_value egit_commit_parent(emacs_env *env, emacs_value _commit, emacs_value 
     int retval = git_commit_parent(&ret, commit, n);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_COMMIT, ret);
+    return egit_wrap(env, EGIT_COMMIT, ret, NULL);
 }
 
 EGIT_DOC(commit_parent_id, "COMMIT &optional N", "Return the ID of the Nth parent of COMMIT.");
@@ -197,7 +197,7 @@ emacs_value egit_commit_tree(emacs_env *env, emacs_value _commit)
     git_tree *tree;
     int retval = git_commit_tree(&tree, commit);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_TREE, tree);
+    return egit_wrap(env, EGIT_TREE, tree, NULL);
 }
 
 EGIT_DOC(commit_tree_id, "COMMIT", "Get the ID of the tree associated with COMMIT.");

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -29,9 +29,9 @@ EGIT_DOC(config_get_bool, "CONFIG NAME",
 emacs_value egit_config_get_bool(emacs_env *env, emacs_value _config, emacs_value _name)
 {
     EGIT_ASSERT_CONFIG(_config);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
     git_config *config = EGIT_EXTRACT(_config);
-    char *name = EGIT_EXTRACT_STRING(_name);
+    char *name = EM_EXTRACT_STRING(_name);
     int value;
     int retval = git_config_get_bool(&value, config, name);
     free(name);
@@ -45,9 +45,9 @@ EGIT_DOC(config_get_int, "CONFIG NAME",
 emacs_value egit_config_get_int(emacs_env *env, emacs_value _config, emacs_value _name)
 {
     EGIT_ASSERT_CONFIG(_config);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
     git_config *config = EGIT_EXTRACT(_config);
-    char *name = EGIT_EXTRACT_STRING(_name);
+    char *name = EM_EXTRACT_STRING(_name);
     int64_t value;
     int retval = git_config_get_int64(&value, config, name);
     free(name);
@@ -63,9 +63,9 @@ EGIT_DOC(config_get_path, "CONFIG NAME",
 emacs_value egit_config_get_path(emacs_env *env, emacs_value _config, emacs_value _name)
 {
     EGIT_ASSERT_CONFIG(_config);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
     git_config *config = EGIT_EXTRACT(_config);
-    char *name = EGIT_EXTRACT_STRING(_name);
+    char *name = EM_EXTRACT_STRING(_name);
 
     git_buf buf = {0};
     int retval = git_config_get_path(&buf, config, name);
@@ -76,7 +76,7 @@ emacs_value egit_config_get_path(emacs_env *env, emacs_value _config, emacs_valu
     // but I trust Emacs' path normalization to be more thorough.
     emacs_value ret = env->make_string(env, buf.ptr, buf.size);
     git_buf_free(&buf);
-    EGIT_NORMALIZE_PATH(ret);
+    EM_NORMALIZE_PATH(ret);
     return ret;
 }
 
@@ -86,9 +86,9 @@ EGIT_DOC(config_get_string, "CONFIG NAME",
 emacs_value egit_config_get_string(emacs_env *env, emacs_value _config, emacs_value _name)
 {
     EGIT_ASSERT_CONFIG(_config);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
     git_config *config = EGIT_EXTRACT(_config);
-    char *name = EGIT_EXTRACT_STRING(_name);
+    char *name = EM_EXTRACT_STRING(_name);
     const char *value;
     int retval = git_config_get_string(&value, config, name);
     free(name);
@@ -115,10 +115,10 @@ EGIT_DOC(config_set_bool, "CONFIG NAME VALUE", "Set the value of NAME in CONFIG 
 emacs_value egit_config_set_bool(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)
 {
     EGIT_ASSERT_CONFIG(_config);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
     git_config *config = EGIT_EXTRACT(_config);
-    const char *name = EGIT_EXTRACT_STRING(_name);
-    int value = EGIT_EXTRACT_BOOLEAN(_value);
+    const char *name = EM_EXTRACT_STRING(_name);
+    int value = EM_EXTRACT_BOOLEAN(_value);
     int retval = git_config_set_bool(config, name, value);
     EGIT_CHECK_ERROR(retval);
     return em_nil;
@@ -128,11 +128,11 @@ EGIT_DOC(config_set_int, "CONFIG NAME VALUE", "Set the value of NAME in CONFIG t
 emacs_value egit_config_set_int(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)
 {
     EGIT_ASSERT_CONFIG(_config);
-    EGIT_ASSERT_STRING(_name);
-    EGIT_ASSERT_INTEGER(_value);
+    EM_ASSERT_STRING(_name);
+    EM_ASSERT_INTEGER(_value);
     git_config *config = EGIT_EXTRACT(_config);
-    const char *name = EGIT_EXTRACT_STRING(_name);
-    int64_t value = EGIT_EXTRACT_INTEGER(_value);
+    const char *name = EM_EXTRACT_STRING(_name);
+    int64_t value = EM_EXTRACT_INTEGER(_value);
     int retval = git_config_set_int64(config, name, value);
     EGIT_CHECK_ERROR(retval);
     return em_nil;
@@ -142,11 +142,11 @@ EGIT_DOC(config_set_string, "CONFIG NAME VALUE", "Set the value of NAME in CONFI
 emacs_value egit_config_set_string(emacs_env *env, emacs_value _config, emacs_value _name, emacs_value _value)
 {
     EGIT_ASSERT_CONFIG(_config);
-    EGIT_ASSERT_STRING(_name);
-    EGIT_ASSERT_STRING(_value);
+    EM_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_value);
     git_config *config = EGIT_EXTRACT(_config);
-    const char *name = EGIT_EXTRACT_STRING(_name);
-    const char *value = EGIT_EXTRACT_STRING(_value);
+    const char *name = EM_EXTRACT_STRING(_name);
+    const char *value = EM_EXTRACT_STRING(_value);
     int retval = git_config_set_string(config, name, value);
     EGIT_CHECK_ERROR(retval);
     return em_nil;
@@ -163,7 +163,7 @@ emacs_value egit_config_find_global(emacs_env *env)
     int retval = git_config_find_global(&out);
     EGIT_CHECK_ERROR(retval);
     emacs_value ret = env->make_string(env, out.ptr, out.size);
-    EGIT_NORMALIZE_PATH(ret);
+    EM_NORMALIZE_PATH(ret);
     git_buf_free(&out);
     return ret;
 }
@@ -175,7 +175,7 @@ emacs_value egit_config_find_programdata(emacs_env *env)
     int retval = git_config_find_programdata(&out);
     EGIT_CHECK_ERROR(retval);
     emacs_value ret = env->make_string(env, out.ptr, out.size);
-    EGIT_NORMALIZE_PATH(ret);
+    EM_NORMALIZE_PATH(ret);
     git_buf_free(&out);
     return ret;
 }
@@ -187,7 +187,7 @@ emacs_value egit_config_find_system(emacs_env *env)
     int retval = git_config_find_system(&out);
     EGIT_CHECK_ERROR(retval);
     emacs_value ret = env->make_string(env, out.ptr, out.size);
-    EGIT_NORMALIZE_PATH(ret);
+    EM_NORMALIZE_PATH(ret);
     git_buf_free(&out);
     return ret;
 }
@@ -199,7 +199,7 @@ emacs_value egit_config_find_xdg(emacs_env *env)
     int retval = git_config_find_xdg(&out);
     EGIT_CHECK_ERROR(retval);
     emacs_value ret = env->make_string(env, out.ptr, out.size);
-    EGIT_NORMALIZE_PATH(ret);
+    EM_NORMALIZE_PATH(ret);
     git_buf_free(&out);
     return ret;
 }

--- a/src/egit-config.c
+++ b/src/egit-config.c
@@ -16,7 +16,7 @@ emacs_value egit_config_snapshot(emacs_env *env, emacs_value _config)
     git_config *snapshot;
     int retval = git_config_snapshot(&snapshot, config);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_CONFIG, snapshot);
+    return egit_wrap(env, EGIT_CONFIG, snapshot, NULL);
 }
 
 
@@ -104,7 +104,7 @@ emacs_value egit_config_lock(emacs_env *env, emacs_value _config)
     git_transaction *trans;
     int retval = git_config_lock(&trans, config);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_TRANSACTION, trans);
+    return egit_wrap(env, EGIT_TRANSACTION, trans, NULL);
 }
 
 

--- a/src/egit-ignore.c
+++ b/src/egit-ignore.c
@@ -10,12 +10,12 @@ EGIT_DOC(add_rule, "REPO RULES",
 emacs_value egit_add_rule(emacs_env *env, emacs_value _repo, emacs_value _rules)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_rules);
+    EM_ASSERT_STRING(_rules);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     int retval;
     {
-        char *rules = EGIT_EXTRACT_STRING(_rules);
+        char *rules = EM_EXTRACT_STRING(_rules);
         retval = git_ignore_add_rule(repo, rules);
         free(rules);
     }
@@ -43,14 +43,14 @@ EGIT_DOC(path_ignored_p, "REPO PATH", "Check if PATH is ignored");
 emacs_value egit_path_ignored_p(emacs_env *env, emacs_value _repo, emacs_value _path)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_path);
+    EM_ASSERT_STRING(_path);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
 
     int out;
     int retval;
     {
-        char *path = EGIT_EXTRACT_STRING(_path)
+        char *path = EM_EXTRACT_STRING(_path)
         retval = git_ignore_path_is_ignored(&out, repo, path);
         free(path);
     }

--- a/src/egit-index.c
+++ b/src/egit-index.c
@@ -84,9 +84,9 @@ emacs_value egit_index_conflict_foreach(emacs_env *env, emacs_value _index, emac
 
         emacs_value args[4];
         args[0] = env->make_string(env, base->path, strlen(base->path));
-        args[1] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(base));
-        args[2] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(ours));
-        args[3] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(theirs));
+        args[1] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(base), NULL);
+        args[2] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(ours), NULL);
+        args[3] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(theirs), NULL);
         env->funcall(env, function, 4, args);
 
         if (env->non_local_exit_check(env))
@@ -109,9 +109,9 @@ emacs_value egit_index_conflict_get(emacs_env *env, emacs_value _index, emacs_va
     EGIT_CHECK_ERROR(retval);
 
     emacs_value ret[3];
-    ret[0] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(base));
-    ret[1] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(ours));
-    ret[2] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(theirs));
+    ret[0] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(base), NULL);
+    ret[1] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(ours), NULL);
+    ret[2] = egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(theirs), NULL);
     return em_list(env, ret, 3);
 }
 
@@ -173,7 +173,7 @@ emacs_value egit_index_get_byindex(emacs_env *env, emacs_value _index, emacs_val
         em_signal_args_out_of_range(env, n);
         return em_nil;
     }
-    return egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(entry));
+    return egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(entry), NULL);
 }
 
 EGIT_DOC(index_get_bypath, "INDEX PATH &optional STAGE",
@@ -207,7 +207,7 @@ emacs_value egit_index_get_bypath(emacs_env *env, emacs_value _index, emacs_valu
 
     if (!entry)
         return em_nil; // TODO: Better to signal an error?
-    return egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(entry));
+    return egit_wrap(env, EGIT_INDEX_ENTRY, egit_index_entry_dup(entry), NULL);
 }
 
 EGIT_DOC(index_owner, "INDEX", "Return the repository associated with INDEX.");
@@ -216,7 +216,7 @@ emacs_value egit_index_owner(emacs_env *env, emacs_value _index)
     EGIT_ASSERT_INDEX(_index);
     git_index *index = EGIT_EXTRACT(_index);
     git_repository *repo = git_index_owner(index);
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 EGIT_DOC(index_path, "INDEX", "Get the path to the index file on disk.");

--- a/src/egit-index.c
+++ b/src/egit-index.c
@@ -65,7 +65,7 @@ EGIT_DOC(index_conflict_foreach, "INDEX FUNCTION",
 emacs_value egit_index_conflict_foreach(emacs_env *env, emacs_value _index, emacs_value function)
 {
     EGIT_ASSERT_INDEX(_index);
-    EGIT_ASSERT_FUNCTION(function);
+    EM_ASSERT_FUNCTION(function);
     git_index *index = EGIT_EXTRACT(_index);
     git_index_conflict_iterator *iter;
     int retval = git_index_conflict_iterator_new(&iter, index);
@@ -100,9 +100,9 @@ EGIT_DOC(index_conflict_get, "INDEX PATH",
 emacs_value egit_index_conflict_get(emacs_env *env, emacs_value _index, emacs_value _path)
 {
     EGIT_ASSERT_INDEX(_index);
-    EGIT_ASSERT_STRING(_path);
+    EM_ASSERT_STRING(_path);
     git_index *index = EGIT_EXTRACT(_index);
-    char *path = EGIT_EXTRACT_STRING(_path);
+    char *path = EM_EXTRACT_STRING(_path);
     const git_index_entry *base, *ours, *theirs;
     int retval = git_index_conflict_get(&base, &ours, &theirs, index, path);
     free(path);
@@ -165,9 +165,9 @@ EGIT_DOC(index_get_byindex, "INDEX N", "Get the Nth entry in INDEX.");
 emacs_value egit_index_get_byindex(emacs_env *env, emacs_value _index, emacs_value _n)
 {
     EGIT_ASSERT_INDEX(_index);
-    EGIT_ASSERT_INTEGER(_n);
+    EM_ASSERT_INTEGER(_n);
     git_index *index = EGIT_EXTRACT(_index);
-    intmax_t n = EGIT_EXTRACT_INTEGER(_n);
+    intmax_t n = EM_EXTRACT_INTEGER(_n);
     const git_index_entry *entry = git_index_get_byindex(index, n);
     if (!entry) {
         em_signal_args_out_of_range(env, n);
@@ -184,10 +184,10 @@ EGIT_DOC(index_get_bypath, "INDEX PATH &optional STAGE",
 emacs_value egit_index_get_bypath(emacs_env *env, emacs_value _index, emacs_value _path, emacs_value _stage)
 {
     EGIT_ASSERT_INDEX(_index);
-    EGIT_ASSERT_STRING(_path);
+    EM_ASSERT_STRING(_path);
 
     int stage;
-    if (!EGIT_EXTRACT_BOOLEAN(_stage))
+    if (!EM_EXTRACT_BOOLEAN(_stage))
         stage = 0;
     else if (env->eq(env, _stage, em_base))
         stage = 1;
@@ -201,7 +201,7 @@ emacs_value egit_index_get_bypath(emacs_env *env, emacs_value _index, emacs_valu
     }
 
     git_index *index = EGIT_EXTRACT(_index);
-    char *path = EGIT_EXTRACT_STRING(_path);
+    char *path = EM_EXTRACT_STRING(_path);
     const git_index_entry *entry = git_index_get_bypath(index, path, stage);
     free(path);
 

--- a/src/egit-object.c
+++ b/src/egit-object.c
@@ -44,7 +44,7 @@ emacs_value egit_object_lookup(emacs_env *env, emacs_value _repo, emacs_value _o
     int retval = git_object_lookup(&object, repo, &oid, type);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_OBJECT, object);
+    return egit_wrap(env, EGIT_OBJECT, object, NULL);
 }
 
 EGIT_DOC(object_lookup_prefix, "REPO OID",
@@ -84,7 +84,7 @@ emacs_value egit_object_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_v
     int retval = git_object_lookup_prefix(&object, repo, &oid, len, type);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_OBJECT, object);
+    return egit_wrap(env, EGIT_OBJECT, object, NULL);
 }
 
 
@@ -107,7 +107,7 @@ emacs_value egit_object_owner(emacs_env *env, emacs_value _object)
     EGIT_ASSERT_OBJECT(_object);
     git_object *object = EGIT_EXTRACT(_object);
     git_repository *repo = git_object_owner(object);
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 EGIT_DOC(object_short_id, "OBJ", "Return the shortened ID for the given OBJ.");

--- a/src/egit-object.c
+++ b/src/egit-object.c
@@ -18,14 +18,14 @@ EGIT_DOC(object_lookup, "REPO OID &optional TYPE",
 emacs_value egit_object_lookup(emacs_env *env, emacs_value _repo, emacs_value _oid, emacs_value _type)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_oid);
+    EM_ASSERT_STRING(_oid);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid oid;
     EGIT_EXTRACT_OID(_oid, oid);
 
     git_otype type;
-    if (!EGIT_EXTRACT_BOOLEAN(_type))
+    if (!EM_EXTRACT_BOOLEAN(_type))
         type = GIT_OBJ_ANY;
     else if (env->eq(env, _type, em_blob))
         type = GIT_OBJ_BLOB;
@@ -57,7 +57,7 @@ EGIT_DOC(object_lookup_prefix, "REPO OID",
 emacs_value egit_object_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_value _oid, emacs_value _type)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_oid);
+    EM_ASSERT_STRING(_oid);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid oid;
@@ -65,7 +65,7 @@ emacs_value egit_object_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_v
     EGIT_EXTRACT_OID_PREFIX(_oid, oid, len);
 
     git_otype type;
-    if (!EGIT_EXTRACT_BOOLEAN(_type))
+    if (!EM_EXTRACT_BOOLEAN(_type))
         type = GIT_OBJ_ANY;
     else if (env->eq(env, _type, em_blob))
         type = GIT_OBJ_BLOB;

--- a/src/egit-reference.c
+++ b/src/egit-reference.c
@@ -36,7 +36,7 @@ emacs_value egit_reference_create(
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 EGIT_DOC(reference_create_matching, "REPO NAME ID &optional FORCE CURRENT-ID LOG-MESSAGE",
@@ -72,7 +72,7 @@ emacs_value egit_reference_create_matching(
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 EGIT_DOC(reference_dup, "REF", "Duplicate an existing reference.");
@@ -83,7 +83,7 @@ emacs_value egit_reference_dup(emacs_env *env, emacs_value _ref)
     git_reference *new_ref;
     int retval = git_reference_dup(&new_ref, ref);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_REFERENCE, new_ref);
+    return egit_wrap(env, EGIT_REFERENCE, new_ref, NULL);
 }
 
 EGIT_DOC(reference_dwim, "REPO SHORTHAND", "Lookup a reference by DWIMing its short name.");
@@ -102,7 +102,7 @@ emacs_value egit_reference_dwim(emacs_env *env, emacs_value _repo, emacs_value _
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 EGIT_DOC(reference_lookup, "REPO NAME", "Lookup a reference by NAME in REPO.");
@@ -121,7 +121,7 @@ emacs_value egit_reference_lookup(emacs_env *env, emacs_value _repo, emacs_value
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 
@@ -183,7 +183,7 @@ emacs_value egit_reference_owner(emacs_env *env, emacs_value _ref)
     EGIT_ASSERT_REFERENCE(_ref);
     git_reference *ref = EGIT_EXTRACT(_ref);
     git_repository *repo = git_reference_owner(ref);
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 EGIT_DOC(reference_peel, "REF &optional TYPE",
@@ -215,7 +215,7 @@ emacs_value egit_reference_peel(emacs_env *env, emacs_value _ref, emacs_value _t
     int retval = git_reference_peel(&obj, ref, type);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_OBJECT, obj);
+    return egit_wrap(env, EGIT_OBJECT, obj, NULL);
 }
 
 EGIT_DOC(reference_resolve, "REF",
@@ -227,7 +227,7 @@ emacs_value egit_reference_resolve(emacs_env *env, emacs_value _ref)
     git_reference *newref;
     int retval = git_reference_resolve(&newref, ref);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_REFERENCE, newref);
+    return egit_wrap(env, EGIT_REFERENCE, newref, NULL);
 }
 
 EGIT_DOC(reference_shorthand, "REF", "Get the short name of REF.");

--- a/src/egit-reference.c
+++ b/src/egit-reference.c
@@ -17,22 +17,22 @@ emacs_value egit_reference_create(
     emacs_value _force, emacs_value _log_message)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_name);
-    EGIT_ASSERT_STRING(_id);
-    EGIT_ASSERT_STRING_OR_NIL(_log_message);
+    EM_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_id);
+    EM_ASSERT_STRING_OR_NIL(_log_message);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid id;
     EGIT_EXTRACT_OID(_id, id);
-    int force = EGIT_EXTRACT_BOOLEAN(_force);
+    int force = EM_EXTRACT_BOOLEAN(_force);
     git_reference *ref;
     int retval;
     {
-        char *name = EGIT_EXTRACT_STRING(_name);
-        char *log_message = EGIT_EXTRACT_STRING_OR_NULL(_log_message);
+        char *name = EM_EXTRACT_STRING(_name);
+        char *log_message = EM_EXTRACT_STRING_OR_NULL(_log_message);
         retval = git_reference_create(&ref, repo, name, &id, force, log_message);
         free(name);
-        EGIT_FREE(log_message);
+        free(log_message);
     }
     EGIT_CHECK_ERROR(retval);
 
@@ -46,29 +46,29 @@ emacs_value egit_reference_create_matching(
     emacs_value _force, emacs_value _current_id, emacs_value _log_message)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_name);
-    EGIT_ASSERT_STRING(_id);
-    EGIT_ASSERT_STRING_OR_NIL(_current_id);
-    EGIT_ASSERT_STRING_OR_NIL(_log_message);
+    EM_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_id);
+    EM_ASSERT_STRING_OR_NIL(_current_id);
+    EM_ASSERT_STRING_OR_NIL(_log_message);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid id, current_id;
     EGIT_EXTRACT_OID(_id, id);
-    if (EGIT_EXTRACT_BOOLEAN(_current_id))
+    if (EM_EXTRACT_BOOLEAN(_current_id))
         EGIT_EXTRACT_OID(_current_id, current_id);
-    int force = EGIT_EXTRACT_BOOLEAN(_force);
+    int force = EM_EXTRACT_BOOLEAN(_force);
     git_reference *ref;
     int retval;
     {
-        char *name = EGIT_EXTRACT_STRING(_name);
-        char *log_message = EGIT_EXTRACT_STRING_OR_NULL(_log_message);
+        char *name = EM_EXTRACT_STRING(_name);
+        char *log_message = EM_EXTRACT_STRING_OR_NULL(_log_message);
         retval = git_reference_create_matching(
             &ref, repo, name, &id, force,
-            EGIT_EXTRACT_BOOLEAN(_current_id) ? &current_id : NULL,
+            EM_EXTRACT_BOOLEAN(_current_id) ? &current_id : NULL,
             log_message
         );
         free(name);
-        EGIT_FREE(log_message);
+        free(log_message);
     }
     EGIT_CHECK_ERROR(retval);
 
@@ -90,13 +90,13 @@ EGIT_DOC(reference_dwim, "REPO SHORTHAND", "Lookup a reference by DWIMing its sh
 emacs_value egit_reference_dwim(emacs_env *env, emacs_value _repo, emacs_value _shorthand)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_shorthand);
+    EM_ASSERT_STRING(_shorthand);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_reference *ref;
     int retval;
     {
-        char *shorthand = EGIT_EXTRACT_STRING(_shorthand);
+        char *shorthand = EM_EXTRACT_STRING(_shorthand);
         retval = git_reference_dwim(&ref, repo, shorthand);
         free(shorthand);
     }
@@ -109,13 +109,13 @@ EGIT_DOC(reference_lookup, "REPO NAME", "Lookup a reference by NAME in REPO.");
 emacs_value egit_reference_lookup(emacs_env *env, emacs_value _repo, emacs_value _name)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_reference *ref;
     int retval;
     {
-        char *name = EGIT_EXTRACT_STRING(_name);
+        char *name = EM_EXTRACT_STRING(_name);
         retval = git_reference_lookup(&ref, repo, name);
         free(name);
     }
@@ -161,13 +161,13 @@ EGIT_DOC(reference_name_to_id, "REPO REFNAME",
 emacs_value egit_reference_name_to_id(emacs_env *env, emacs_value _repo, emacs_value _refname)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_refname);
+    EM_ASSERT_STRING(_refname);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid oid;
     int retval;
     {
-        char *refname = EGIT_EXTRACT_STRING(_refname);
+        char *refname = EM_EXTRACT_STRING(_refname);
         retval = git_reference_name_to_id(&oid, repo, refname);
         free(refname);
     }
@@ -195,7 +195,7 @@ emacs_value egit_reference_peel(emacs_env *env, emacs_value _ref, emacs_value _t
     EGIT_ASSERT_REFERENCE(_ref);
 
     git_otype type;
-    if (!EGIT_EXTRACT_BOOLEAN(_type))
+    if (!EM_EXTRACT_BOOLEAN(_type))
         type = GIT_OBJ_ANY;
     else if (env->eq(env, _type, em_commit))
         type = GIT_OBJ_COMMIT;
@@ -301,12 +301,12 @@ EGIT_DOC(reference_ensure_log, "REPO REFNAME",
 emacs_value egit_reference_ensure_log(emacs_env *env, emacs_value _repo, emacs_value _refname)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_refname);
+    EM_ASSERT_STRING(_refname);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     int retval;
     {
-        char *refname = EGIT_EXTRACT_STRING(_refname);
+        char *refname = EM_EXTRACT_STRING(_refname);
         retval = git_reference_ensure_log(repo, refname);
         free(refname);
     }
@@ -319,12 +319,12 @@ EGIT_DOC(reference_remove, "REF", "Remove an existing reference by name.");
 emacs_value egit_reference_remove(emacs_env *env, emacs_value _repo, emacs_value _refname)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_refname);
+    EM_ASSERT_STRING(_refname);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     int retval;
     {
-        char *refname = EGIT_EXTRACT_STRING(_refname);
+        char *refname = EM_EXTRACT_STRING(_refname);
         retval = git_reference_remove(repo, refname);
         free(refname);
     }
@@ -360,12 +360,12 @@ EGIT_DOC(reference_has_log_p, "REPO REFNAME",
 emacs_value egit_reference_has_log_p(emacs_env *env, emacs_value _repo, emacs_value _refname)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_refname);
+    EM_ASSERT_STRING(_refname);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     int retval;
     {
-        char *refname = EGIT_EXTRACT_STRING(_refname);
+        char *refname = EM_EXTRACT_STRING(_refname);
         retval = git_reference_has_log(repo, refname);
         free(refname);
     }
@@ -413,11 +413,11 @@ emacs_value egit_reference_tag_p(emacs_env *env, emacs_value _ref)
 EGIT_DOC(reference_valid_name_p, "REFNAME", "Check if a reference name is well-formed.");
 emacs_value egit_reference_valid_name_p(emacs_env *env, emacs_value _refname)
 {
-    EGIT_ASSERT_STRING(_refname);
+    EM_ASSERT_STRING(_refname);
 
     int retval;
     {
-        char *refname = EGIT_EXTRACT_STRING(_refname);
+        char *refname = EM_EXTRACT_STRING(_refname);
         retval = git_reference_is_valid_name(refname);
         free(refname);
     }

--- a/src/egit-repository.c
+++ b/src/egit-repository.c
@@ -28,7 +28,7 @@ emacs_value egit_repository_init(emacs_env *env, emacs_value _path, emacs_value 
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 EGIT_DOC(repository_open, "PATH", "Open an existing repository at PATH.");
@@ -46,7 +46,7 @@ emacs_value egit_repository_open(emacs_env *env, emacs_value _path)
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 EGIT_DOC(repository_open_bare, "PATH",
@@ -66,7 +66,7 @@ emacs_value egit_repository_open_bare(emacs_env *env, emacs_value _path)
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 
@@ -92,7 +92,7 @@ emacs_value egit_repository_config(emacs_env *env, emacs_value _repo)
     git_config *config;
     int retval = git_repository_config(&config, repo);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_CONFIG, config);
+    return egit_wrap(env, EGIT_CONFIG, config, NULL);
 }
 
 EGIT_DOC(repository_get_namespace, "REPO",
@@ -114,7 +114,7 @@ emacs_value egit_repository_head(emacs_env *env, emacs_value _repo)
     git_reference *ref;
     int retval = git_repository_head(&ref, repo);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 EGIT_DOC(repository_head_for_worktree, "REPO NAME",
@@ -134,7 +134,7 @@ emacs_value egit_repository_head_for_worktree(emacs_env *env, emacs_value _repo,
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_REFERENCE, ref);
+    return egit_wrap(env, EGIT_REFERENCE, ref, NULL);
 }
 
 EGIT_DOC(repository_ident, "REPO",
@@ -160,7 +160,7 @@ emacs_value egit_repository_index(emacs_env *env, emacs_value _repo)
     git_index *index;
     int retval = git_repository_index(&index, repo);
     EGIT_CHECK_ERROR(retval);
-    return egit_wrap(env, EGIT_INDEX, index);
+    return egit_wrap(env, EGIT_INDEX, index, NULL);
 }
 
 EGIT_DOC(repository_message, "REPO",

--- a/src/egit-repository.c
+++ b/src/egit-repository.c
@@ -15,14 +15,14 @@ EGIT_DOC(repository_init, "PATH &optional IS-BARE",
          "If IS-BARE then create a bare repository.");
 emacs_value egit_repository_init(emacs_env *env, emacs_value _path, emacs_value _is_bare)
 {
-    EGIT_ASSERT_STRING(_path);
-    EGIT_NORMALIZE_PATH(_path);
+    EM_ASSERT_STRING(_path);
+    EM_NORMALIZE_PATH(_path);
 
     git_repository *repo;
-    unsigned int is_bare = EGIT_EXTRACT_BOOLEAN(_is_bare);
+    unsigned int is_bare = EM_EXTRACT_BOOLEAN(_is_bare);
     int retval;
     {
-        char *path = EGIT_EXTRACT_STRING(_path);
+        char *path = EM_EXTRACT_STRING(_path);
         retval = git_repository_init(&repo, path, is_bare);
         free(path);
     }
@@ -34,13 +34,13 @@ emacs_value egit_repository_init(emacs_env *env, emacs_value _path, emacs_value 
 EGIT_DOC(repository_open, "PATH", "Open an existing repository at PATH.");
 emacs_value egit_repository_open(emacs_env *env, emacs_value _path)
 {
-    EGIT_ASSERT_STRING(_path);
-    EGIT_NORMALIZE_PATH(_path);
+    EM_ASSERT_STRING(_path);
+    EM_NORMALIZE_PATH(_path);
 
     git_repository *repo;
     int retval;
     {
-        char *path = EGIT_EXTRACT_STRING(_path);
+        char *path = EM_EXTRACT_STRING(_path);
         retval = git_repository_open(&repo, path);
         free(path);
     }
@@ -54,13 +54,13 @@ EGIT_DOC(repository_open_bare, "PATH",
          "This is faster than `git-repository-open'.");
 emacs_value egit_repository_open_bare(emacs_env *env, emacs_value _path)
 {
-    EGIT_ASSERT_STRING(_path);
-    EGIT_NORMALIZE_PATH(_path);
+    EM_ASSERT_STRING(_path);
+    EM_NORMALIZE_PATH(_path);
 
     git_repository *repo;
     int retval;
     {
-        char *path = EGIT_EXTRACT_STRING(_path);
+        char *path = EM_EXTRACT_STRING(_path);
         retval = git_repository_open_bare(&repo, path);
         free(path);
     }
@@ -80,7 +80,7 @@ emacs_value egit_repository_commondir(emacs_env *env, emacs_value _repo)
     git_repository *repo = EGIT_EXTRACT(_repo);
     const char *path = git_repository_commondir(repo);
     emacs_value retval = env->make_string(env, path, strlen(path));
-    EGIT_NORMALIZE_PATH(retval);
+    EM_NORMALIZE_PATH(retval);
     return retval;
 }
 
@@ -122,13 +122,13 @@ EGIT_DOC(repository_head_for_worktree, "REPO NAME",
 emacs_value egit_repository_head_for_worktree(emacs_env *env, emacs_value _repo, emacs_value _name)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_reference *ref;
     int retval;
     {
-        char *name = EGIT_EXTRACT_STRING(_name);
+        char *name = EM_EXTRACT_STRING(_name);
         retval = git_repository_head_for_worktree(&ref, repo, name);
         free(name);
     }
@@ -186,7 +186,7 @@ emacs_value egit_repository_path(emacs_env *env, emacs_value _repo)
     git_repository *repo = EGIT_EXTRACT(_repo);
     const char *path = git_repository_path(repo);
     emacs_value retval = env->make_string(env, path, strlen(path));
-    EGIT_NORMALIZE_PATH(retval);
+    EM_NORMALIZE_PATH(retval);
     return retval;
 }
 
@@ -235,7 +235,7 @@ emacs_value egit_repository_workdir(emacs_env *env, emacs_value _repo)
     if (!path)
         return em_nil;
     emacs_value retval = env->make_string(env, path, strlen(path));
-    EGIT_NORMALIZE_PATH(retval);
+    EM_NORMALIZE_PATH(retval);
     return retval;
 }
 
@@ -274,12 +274,12 @@ EGIT_DOC(repository_set_head, "REPO REFNAME",
 emacs_value egit_repository_set_head(emacs_env *env, emacs_value _repo, emacs_value _refname)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_refname);
+    EM_ASSERT_STRING(_refname);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     int retval;
     {
-        char *refname = EGIT_EXTRACT_STRING(_refname);
+        char *refname = EM_EXTRACT_STRING(_refname);
         retval = git_repository_set_head(repo, refname);
         free(refname);
     }
@@ -293,7 +293,7 @@ EGIT_DOC(repository_set_head_detached, "REPO COMMITISH",
 emacs_value egit_repository_set_head_detached(emacs_env *env, emacs_value _repo, emacs_value _commitish)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_commitish);
+    EM_ASSERT_STRING(_commitish);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid commitish;
@@ -311,17 +311,17 @@ emacs_value egit_repository_set_ident(
     emacs_env *env, emacs_value _repo, emacs_value _name, emacs_value _email)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING_OR_NIL(_name);
-    EGIT_ASSERT_STRING_OR_NIL(_email);
+    EM_ASSERT_STRING_OR_NIL(_name);
+    EM_ASSERT_STRING_OR_NIL(_email);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     int retval;
     {
-        char *name = EGIT_EXTRACT_STRING_OR_NULL(_name);
-        char *email = EGIT_EXTRACT_STRING_OR_NULL(_email);
+        char *name = EM_EXTRACT_STRING_OR_NULL(_name);
+        char *email = EM_EXTRACT_STRING_OR_NULL(_email);
         retval = git_repository_set_ident(repo, name, email);
-        EGIT_FREE(name);
-        EGIT_FREE(email);
+        free(name);
+        free(email);
     }
     EGIT_CHECK_ERROR(retval);
 
@@ -334,12 +334,12 @@ emacs_value egit_repository_set_namespace(
     emacs_env *env, emacs_value _repo, emacs_value _nmspace)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_nmspace);
+    EM_ASSERT_STRING(_nmspace);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     int retval;
     {
-        char *nmspace = EGIT_EXTRACT_STRING(_nmspace);
+        char *nmspace = EM_EXTRACT_STRING(_nmspace);
         retval = git_repository_set_namespace(repo, nmspace);
         free(nmspace);
     }
@@ -354,14 +354,14 @@ emacs_value egit_repository_set_workdir(
     emacs_env *env, emacs_value _repo, emacs_value _workdir, emacs_value _update_gitlink)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_workdir);
-    EGIT_NORMALIZE_PATH(_workdir);
+    EM_ASSERT_STRING(_workdir);
+    EM_NORMALIZE_PATH(_workdir);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
-    int update_gitlink = EGIT_EXTRACT_BOOLEAN(_update_gitlink);
+    int update_gitlink = EM_EXTRACT_BOOLEAN(_update_gitlink);
     int retval;
     {
-        char *workdir = EGIT_EXTRACT_STRING(_workdir);
+        char *workdir = EM_EXTRACT_STRING(_workdir);
         retval = git_repository_set_workdir(repo, workdir, update_gitlink);
         free(workdir);
     }
@@ -450,43 +450,43 @@ EGIT_DOC(repository_discover, "&optional PATH ACROSS-FS CEILING-DIRS",
          "CEILING-DIRS is a list of paths where lookup will stop.");
 emacs_value egit_repository_discover(emacs_env *env, emacs_value _path, emacs_value _across_fs, emacs_value _ceiling_dirs)
 {
-    EGIT_ASSERT_STRING_OR_NIL(_path);
+    EM_ASSERT_STRING_OR_NIL(_path);
 
     // Check that _ceiling_dirs is a list of strings, and get the total length
     // of the buffer we need, including separators
     ptrdiff_t totsize = 0, size;
     {
-        EGIT_DOLIST(car, _ceiling_dirs, count);
-        EGIT_ASSERT_STRING(car);
+        EM_DOLIST(car, _ceiling_dirs, count);
+        EM_ASSERT_STRING(car);
         if (totsize > 0) totsize++;          // Space for the separator
         env->copy_string_contents(env, car, NULL, &size);
         totsize += size - 1;                 // Ignore the terminating null character
-        EGIT_DOLIST_END(count);
+        EM_DOLIST_END(count);
     }
 
     // Allocate a buffer with the right size, and copy the string contents
     char *ceiling_dirs = (char*) malloc((totsize + 1) * sizeof(char));
     char *next = ceiling_dirs;
     {
-        EGIT_DOLIST(car, _ceiling_dirs, copy);
+        EM_DOLIST(car, _ceiling_dirs, copy);
         if (next != ceiling_dirs)
             *(next++) = GIT_PATH_LIST_SEPARATOR;
         env->copy_string_contents(env, car, NULL, &size);
         env->copy_string_contents(env, car, next, &size);
         next += size - 1;
-        EGIT_DOLIST_END(copy);
+        EM_DOLIST_END(copy);
     }
     *next = '\0';
 
     char *path;
-    if (EGIT_EXTRACT_BOOLEAN(_path)) {
-        EGIT_NORMALIZE_PATH(_path);
-        path = EGIT_EXTRACT_STRING(_path);
+    if (EM_EXTRACT_BOOLEAN(_path)) {
+        EM_NORMALIZE_PATH(_path);
+        path = EM_EXTRACT_STRING(_path);
     }
     else
         path = em_default_directory(env);
 
-    int across_fs = EGIT_EXTRACT_BOOLEAN(_across_fs);
+    int across_fs = EM_EXTRACT_BOOLEAN(_across_fs);
 
     git_buf out = {0};
     int retval = git_repository_discover(&out, path, across_fs, ceiling_dirs);
@@ -495,7 +495,7 @@ emacs_value egit_repository_discover(emacs_env *env, emacs_value _path, emacs_va
     EGIT_CHECK_ERROR(retval);
 
     emacs_value ret = env->make_string(env, out.ptr, out.size);
-    EGIT_NORMALIZE_PATH(ret);
+    EM_NORMALIZE_PATH(ret);
 
     // NOTE: Renamed to git_buf_dispose in newer libgit2
     git_buf_free(&out);

--- a/src/egit-revparse.c
+++ b/src/egit-revparse.c
@@ -9,13 +9,13 @@ EGIT_DOC(revparse_single, "REPO SPEC", "Return the object referred to by SPEC in
 emacs_value egit_revparse_single(emacs_env *env, emacs_value _repo, emacs_value _spec)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_spec);
+    EM_ASSERT_STRING(_spec);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_object *obj;
     int retval;
     {
-        char *spec = EGIT_EXTRACT_STRING(_spec);
+        char *spec = EM_EXTRACT_STRING(_spec);
         retval = git_revparse_single(&obj, repo, spec);
         free(spec);
     }

--- a/src/egit-revparse.c
+++ b/src/egit-revparse.c
@@ -21,5 +21,5 @@ emacs_value egit_revparse_single(emacs_env *env, emacs_value _repo, emacs_value 
     }
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_OBJECT, obj);
+    return egit_wrap(env, EGIT_OBJECT, obj, NULL);
 }

--- a/src/egit-signature.c
+++ b/src/egit-signature.c
@@ -15,7 +15,7 @@ emacs_value egit_signature_default(emacs_env *env, emacs_value _repo)
     int retval = git_signature_default(&signature, repo);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_SIGNATURE, signature);
+    return egit_wrap(env, EGIT_SIGNATURE, signature, NULL);
 }
 
 EGIT_DOC(signature_name, "SIGNATURE", "Get the name from SIGNATURE.");

--- a/src/egit-status.c
+++ b/src/egit-status.c
@@ -25,8 +25,8 @@ emacs_value egit_status_decode(emacs_env *env, emacs_value status)
     emacs_value statuses[16];
     int nstatuses;
 
-    EGIT_ASSERT_INTEGER(status);
-    flags = EGIT_EXTRACT_INTEGER(status);
+    EM_ASSERT_INTEGER(status);
+    flags = EM_EXTRACT_INTEGER(status);
 
 #define CHECK(name, symbol)                             \
     do {                                                \
@@ -74,10 +74,10 @@ emacs_value egit_status_file(emacs_env *env, emacs_value _repo,
                              emacs_value _path)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_path);
+    EM_ASSERT_STRING(_path);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
-    char *path = EGIT_EXTRACT_STRING(_path);
+    char *path = EM_EXTRACT_STRING(_path);
 
     unsigned int flags;
     int rv = git_status_file(&flags, repo, path);
@@ -95,9 +95,9 @@ emacs_value egit_status_should_ignore_p(emacs_env *env, emacs_value _repo,
                                         emacs_value _path)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_path);
+    EM_ASSERT_STRING(_path);
 
-    char *path = EGIT_EXTRACT_STRING(_path);
+    char *path = EM_EXTRACT_STRING(_path);
     git_repository *repo = EGIT_EXTRACT(_repo);
 
     int ignored;
@@ -207,7 +207,7 @@ bool convert_pathspec_option(git_strarray *out, emacs_env *env,
             return false;
         }
 
-        out->strings[nspecs++] = EGIT_EXTRACT_STRING(elt);
+        out->strings[nspecs++] = EM_EXTRACT_STRING(elt);
         arg = em_cdr(env, arg);
     }
 
@@ -298,7 +298,7 @@ emacs_value egit_status_foreach(emacs_env *env, emacs_value _repo,
                                 emacs_value baseline)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_FUNCTION(function);
+    EM_ASSERT_FUNCTION(function);
 
     git_status_options options;
     git_status_init_options(&options, GIT_STATUS_OPTIONS_VERSION);

--- a/src/egit-tree.c
+++ b/src/egit-tree.c
@@ -64,7 +64,7 @@ emacs_value egit_tree_lookup(emacs_env *env, emacs_value _repo, emacs_value _oid
     int retval = git_tree_lookup(&tree, repo, &oid);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_TREE, tree);
+    return egit_wrap(env, EGIT_TREE, tree, NULL);
 }
 
 EGIT_DOC(tree_lookup_prefix, "REPO OID", "Lookup a tree in REPO by shortened OID.");
@@ -82,7 +82,7 @@ emacs_value egit_tree_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_val
     int retval = git_tree_lookup_prefix(&tree, repo, &oid, len);
     EGIT_CHECK_ERROR(retval);
 
-    return egit_wrap(env, EGIT_TREE, tree);
+    return egit_wrap(env, EGIT_TREE, tree, NULL);
 }
 
 
@@ -195,7 +195,7 @@ emacs_value egit_tree_owner(emacs_env *env, emacs_value _tree)
     EGIT_ASSERT_TREE(_tree);
     git_tree *tree = EGIT_EXTRACT(_tree);
     git_repository *repo = git_tree_owner(tree);
-    return egit_wrap(env, EGIT_REPOSITORY, repo);
+    return egit_wrap(env, EGIT_REPOSITORY, repo, NULL);
 }
 
 

--- a/src/egit-tree.c
+++ b/src/egit-tree.c
@@ -54,7 +54,7 @@ EGIT_DOC(tree_lookup, "REPO OID", "Look up a tree in REPO by OID.");
 emacs_value egit_tree_lookup(emacs_env *env, emacs_value _repo, emacs_value _oid)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_oid);
+    EM_ASSERT_STRING(_oid);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid oid;
@@ -71,7 +71,7 @@ EGIT_DOC(tree_lookup_prefix, "REPO OID", "Lookup a tree in REPO by shortened OID
 emacs_value egit_tree_lookup_prefix(emacs_env *env, emacs_value _repo, emacs_value _oid)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
-    EGIT_ASSERT_STRING(_oid);
+    EM_ASSERT_STRING(_oid);
 
     git_repository *repo = EGIT_EXTRACT(_repo);
     git_oid oid;
@@ -95,7 +95,7 @@ EGIT_DOC(tree_entry_byid, "TREE ID",
 emacs_value egit_tree_entry_byid(emacs_env *env, emacs_value _tree, emacs_value _oid)
 {
     EGIT_ASSERT_TREE(_tree);
-    EGIT_ASSERT_STRING(_oid);
+    EM_ASSERT_STRING(_oid);
     git_tree *tree = EGIT_EXTRACT(_tree);
     git_oid oid;
     EGIT_EXTRACT_OID(_oid, oid);
@@ -125,9 +125,9 @@ EGIT_DOC(tree_entry_byindex, "TREE N",
 emacs_value egit_tree_entry_byindex(emacs_env *env, emacs_value _tree, emacs_value _index)
 {
     EGIT_ASSERT_TREE(_tree);
-    EGIT_ASSERT_INTEGER(_index);
+    EM_ASSERT_INTEGER(_index);
     git_tree *tree = EGIT_EXTRACT(_tree);
-    intmax_t index = EGIT_EXTRACT_INTEGER(_index);
+    intmax_t index = EM_EXTRACT_INTEGER(_index);
     const git_tree_entry *entry = git_tree_entry_byindex(tree, index);
     if (!entry) {
         em_signal_args_out_of_range(env, index);
@@ -142,9 +142,9 @@ EGIT_DOC(tree_entry_byname, "TREE FILENAME",
 emacs_value egit_tree_entry_byname(emacs_env *env, emacs_value _tree, emacs_value _name)
 {
     EGIT_ASSERT_TREE(_tree);
-    EGIT_ASSERT_STRING(_name);
+    EM_ASSERT_STRING(_name);
     git_tree *tree = EGIT_EXTRACT(_tree);
-    char *name = EGIT_EXTRACT_STRING(_name);
+    char *name = EM_EXTRACT_STRING(_name);
     const git_tree_entry *entry = git_tree_entry_byname(tree, name);
     free(name);
     if (!entry)
@@ -158,9 +158,9 @@ EGIT_DOC(tree_entry_bypath, "TREE PATH",
 emacs_value egit_tree_entry_bypath(emacs_env *env, emacs_value _tree, emacs_value _path)
 {
     EGIT_ASSERT_TREE(_tree);
-    EGIT_ASSERT_STRING(_path);
+    EM_ASSERT_STRING(_path);
     git_tree *tree = EGIT_EXTRACT(_tree);
-    char *path = EGIT_EXTRACT_STRING(_path);
+    char *path = EM_EXTRACT_STRING(_path);
     git_tree_entry *entry;
     int retval = git_tree_entry_bypath(&entry, tree, path);
     free(path);
@@ -234,7 +234,7 @@ EGIT_DOC(tree_walk, "TREE ORDER FUNCTION",
 emacs_value egit_tree_walk(emacs_env *env, emacs_value _tree, emacs_value order, emacs_value function)
 {
     EGIT_ASSERT_TREE(_tree);
-    EGIT_ASSERT_FUNCTION(function);
+    EM_ASSERT_FUNCTION(function);
 
     git_treewalk_mode mode;
     if (env->eq(env, order, em_pre))

--- a/src/egit.c
+++ b/src/egit.c
@@ -30,7 +30,7 @@ egit_type egit_get_type(emacs_env *env, emacs_value _obj)
 {
     if (!em_user_ptrp(env, _obj))
         return EGIT_UNKNOWN;
-    egit_object *obj = (egit_object*)env->get_user_ptr(env, _obj);
+    egit_object *obj = (egit_object*) EM_EXTRACT_USER_PTR(_obj);
     return obj->type;
 }
 
@@ -292,7 +292,7 @@ static emacs_value egit_refcount(emacs_env *env, emacs_value val)
 {
     if (egit_get_type(env, val) != EGIT_REPOSITORY)
         return em_nil;
-    egit_object *wrapper = (egit_object*)env->get_user_ptr(env, val);
+    egit_object *wrapper = (egit_object*) EM_EXTRACT_USER_PTR(val);
     return env->make_integer(env, wrapper->refcount);
 }
 

--- a/src/egit.c
+++ b/src/egit.c
@@ -81,7 +81,7 @@ static void egit_decref_direct(egit_object *wrapper)
  * @param data The object to store.
  * @return Pointer to the egit_object wrapper struct.
  */
-static egit_object *egit_incref(egit_type type, void *data)
+static egit_object *egit_incref(egit_type type, const void *data)
 {
     egit_object *wrapper;
     HASH_FIND_PTR(object_store, &data, wrapper);
@@ -95,7 +95,7 @@ static egit_object *egit_incref(egit_type type, void *data)
         wrapper = (egit_object*)malloc(sizeof(egit_object));
         wrapper->type = type;
         wrapper->refcount = 1;
-        wrapper->ptr = data;
+        wrapper->ptr = (void*) data;
         HASH_ADD_PTR(object_store, ptr, wrapper);
     }
 
@@ -162,7 +162,7 @@ static void egit_finalize(void* _obj)
         egit_finalize(parent);
 }
 
-emacs_value egit_wrap(emacs_env *env, egit_type type, void* data, egit_object *parent)
+emacs_value egit_wrap(emacs_env *env, egit_type type, const void* data, egit_object *parent)
 {
     // If it's a git_object, try to be more specific
     if (type == EGIT_OBJECT) {
@@ -199,7 +199,7 @@ emacs_value egit_wrap(emacs_env *env, egit_type type, void* data, egit_object *p
     else {
         wrapper = (egit_object*) malloc(sizeof(egit_object));
         wrapper->type = type;
-        wrapper->ptr = data;
+        wrapper->ptr = (void*) data;
     }
     wrapper->parent = parent;
 

--- a/src/egit.c
+++ b/src/egit.c
@@ -151,12 +151,6 @@ static void egit_finalize(void* _obj)
         git_transaction_free(obj->ptr);
         break;
 
-    // Types that are allocated by us
-    case EGIT_INDEX_ENTRY:
-        free((void*) ((git_index_entry*) obj->ptr)->path);
-        free(obj->ptr);
-        break;
-
     default: break;
     }
 

--- a/src/egit.h
+++ b/src/egit.h
@@ -207,7 +207,7 @@ bool egit_assert_object(emacs_env *env, emacs_value obj);
  * @param ptr The pointer to store.
  * @return The Emacs value.
  */
-emacs_value egit_wrap(emacs_env *env, egit_type type, void* ptr, egit_object *parent);
+emacs_value egit_wrap(emacs_env *env, egit_type type, const void* ptr, egit_object *parent);
 
 /**
  * If libgit2 signaled an error, dispatch that error to Emacs.

--- a/src/egit.h
+++ b/src/egit.h
@@ -81,7 +81,7 @@
  * Extract a libgit git_??? struct from an emacs_value.
  * Caller is responsible for ensuring that this is a valid operation.
  */
-#define EGIT_EXTRACT(val) (((egit_object*)env->get_user_ptr(env, (val)))->ptr)
+#define EGIT_EXTRACT(val) (((egit_object*) EM_EXTRACT_USER_PTR(val))->ptr)
 
 /**
  * Extract a libgit git_??? struct from an emacs_value, or NULL.

--- a/src/egit.h
+++ b/src/egit.h
@@ -24,123 +24,58 @@
     extern const char *egit_##name##__doc;                      \
     emacs_value egit_##name(emacs_env *env, __VA_ARGS__)
 
-/**
- * Variant of EGIT_DEFUN for zero parameters.
- */
+// Variant of EGIT_DEFUN for zero parameters.
 #define EGIT_DEFUN_0(name)                      \
     extern const char *egit_##name##__doc;      \
     emacs_value egit_##name(emacs_env *env)
 
-/**
- * Assert that VAL is a function, signal an error and return otherwise.
- */
-#define EGIT_ASSERT_FUNCTION(val)                                       \
-    do { if (!em_assert(env, em_functionp, (val))) return em_nil; } while (0)
-
-/**
- * Assert that VAL is a string, signal an error and return otherwise.
- */
-#define EGIT_ASSERT_STRING(val)                                         \
-    do { if (!em_assert(env, em_stringp, (val))) return em_nil; } while (0)
-
-/**
- * Assert that VAL is a string or nil, signal an error and return otherwise.
- */
-#define EGIT_ASSERT_STRING_OR_NIL(val) \
-    do { if (EGIT_EXTRACT_BOOLEAN(val)) EGIT_ASSERT_STRING(val); } while (0)
-
-/**
- * Assert that VAL is an integer, signal an error and return otherwise.
- */
-#define EGIT_ASSERT_INTEGER(val)                                        \
-    do { if (!em_assert(env, em_integerp, (val))) return em_nil; } while (0)
-
-/**
- * Assert that VAL is an integer or nil, signal an error and return otherwise.
- */
-#define EGIT_ASSERT_INTEGER_OR_NIL(val) \
-    do { if (EGIT_EXTRACT_BOOLEAN(val)) EGIT_ASSERT_INTEGER(val); } while (0)
-
-/**
- * Assert that VAL is a git blame, signal an error and return otherwise.
- */
-#define EGIT_ASSERT_BLAME(val)                                      \
+// Assert that VAL is a git blame, signal an error and return otherwise.
+#define EGIT_ASSERT_BLAME(val)                                          \
     do { if (!egit_assert_type(env, (val), EGIT_BLAME, em_libgit_blame_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a git commit, signal an error and return otherwise.
- */
+// Assert that VAL is a git commit, signal an error and return otherwise.
 #define EGIT_ASSERT_COMMIT(val)                                         \
     do { if (!egit_assert_type(env, (val), EGIT_COMMIT, em_libgit_commit_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a git config, signal an error and return otherwise.
- */
+// Assert that VAL is a git config, signal an error and return otherwise.
 #define EGIT_ASSERT_CONFIG(val)                                         \
     do { if (!egit_assert_type(env, (val), EGIT_CONFIG, em_libgit_config_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a git index, signal an error and return otherwise.
- */
+// Assert that VAL is a git index, signal an error and return otherwise.
 #define EGIT_ASSERT_INDEX(val)                                          \
     do { if (!egit_assert_type(env, (val), EGIT_INDEX, em_libgit_index_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a git index entry, signal an error and return otherwise.
- */
+// Assert that VAL is a git index entry, signal an error and return otherwise.
 #define EGIT_ASSERT_INDEX_ENTRY(val)                                    \
     do { if (!egit_assert_type(env, (val), EGIT_INDEX_ENTRY, em_libgit_index_entry_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a git object, signal an error and return otherwise.
- */
+// Assert that VAL is a git object, signal an error and return otherwise.
 #define EGIT_ASSERT_OBJECT(val)                                         \
     do { if (!egit_assert_object(env, (val))) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a git reference, signal an error and return otherwise.
- */
+// Assert that VAL is a git reference, signal an error and return otherwise.
 #define EGIT_ASSERT_REFERENCE(val)                                      \
     do { if (!egit_assert_type(env, (val), EGIT_REFERENCE, em_libgit_reference_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a git repository, signal an error and return otherwise.
- */
+// Assert that VAL is a git repository, signal an error and return otherwise.
 #define EGIT_ASSERT_REPOSITORY(val)                                     \
     do { if (!egit_assert_type(env, (val), EGIT_REPOSITORY, em_libgit_repository_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a signature, signal an error and return otherwise.
- */
+// Assert that VAL is a signature, signal an error and return otherwise.
 #define EGIT_ASSERT_SIGNATURE(val)                                     \
     do { if (!egit_assert_type(env, (val), EGIT_SIGNATURE, em_libgit_signature_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a transaction, signal an error and return otherwise.
- */
+// Assert that VAL is a transaction, signal an error and return otherwise.
 #define EGIT_ASSERT_TRANSACTION(val)                                    \
     do { if (!egit_assert_type(env, (val), EGIT_TRANSACTION, em_libgit_transaction_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a transaction, signal an error and return otherwise.
- */
+// Assert that VAL is a transaction, signal an error and return otherwise.
 #define EGIT_ASSERT_TREE(val)                                           \
     do { if (!egit_assert_type(env, (val), EGIT_TREE, em_libgit_tree_p)) return em_nil; } while (0)
 
-/**
- * Assert that VAL is a signature or nil, signal an error and return otherwise.
- */
+// Assert that VAL is a signature or nil, signal an error and return otherwise.
 #define EGIT_ASSERT_SIGNATURE_OR_NIL(val) \
-    do { if (EGIT_EXTRACT_BOOLEAN(val)) EGIT_ASSERT_SIGNATURE(val); } while (0)
-
-/**
- * Normalize an emacs_value string path. This macro may return.
- */
-#define EGIT_NORMALIZE_PATH(val)\
-    do {                                                        \
-        (val) = em_expand_file_name(env, val);                  \
-        if (env->non_local_exit_check(env)) return em_nil;      \
-    } while (0)
+    do { if (EM_EXTRACT_BOOLEAN(val)) EGIT_ASSERT_SIGNATURE(val); } while (0)
 
 /**
  * Extract a libgit git_??? struct from an emacs_value.
@@ -152,45 +87,8 @@
  * Extract a libgit git_??? struct from an emacs_value, or NULL.
  * Caller is responsible for ensuring that this is a valid operation.
  */
-
 #define EGIT_EXTRACT_OR_NULL(val)                                \
-  (EGIT_EXTRACT_BOOLEAN(val) ? EGIT_EXTRACT(val) : NULL);
-
-/**
- * Extract a boolean from an emacs_value.
- */
-#define EGIT_EXTRACT_BOOLEAN(val) (env->is_not_nil(env, (val)) ? 1 : 0)
-
-/**
- * Extract a string from an emacs_value.
- * Caller is reponsible for ensuring that the emacs_value represents a string.
- */
-#define EGIT_EXTRACT_STRING(val) em_get_string(env, (val));
-
-/**
- * Extract an integer from an emacs_value.
- * Caller is reponsible for ensuring that the emacs_value represents an integer.
- */
-#define EGIT_EXTRACT_INTEGER(val) env->extract_integer(env, (val))
-
-/**
- * Extract an integer from an emacs_value with a default.
- * Caller is reponsible for ensuring that the emacs_value represents an integer.
- */
-#define EGIT_EXTRACT_INTEGER_OR_DEFAULT(val, default)                   \
-    (EGIT_EXTRACT_BOOLEAN(val) ? EGIT_EXTRACT_INTEGER(val) : (default))
-
-/**
- * Extract a string from an emacs_value, or NULL.
- * Caller is reponsible for ensuring that the emacs_value represents a string or nil.
- */
-#define EGIT_EXTRACT_STRING_OR_NULL(val)                                \
-    (EGIT_EXTRACT_BOOLEAN(val) ? em_get_string(env, (val)) : NULL);
-
-/**
- * Free a pointer if it is non-NULL.
- */
-#define EGIT_FREE(val) do { if (val) free(val); } while (0)
+  (EM_EXTRACT_BOOLEAN(val) ? EGIT_EXTRACT(val) : NULL);
 
 /**
  * Extract a git_oid from an emacs_value.
@@ -235,29 +133,6 @@
     } while (0)
 
 /**
- * Initiate a loop over an Emacs list.
- * If any element is not a cons cell or nil, it WILL signal an error and return nil.
- * @param var Variable bound to each car.
- * @param listvar List to loop over.
- * @param name Unique name identifying the loop.
- */
-#define EGIT_DOLIST(var, listvar, name)                             \
-    emacs_value __cell##name = (listvar);                           \
-    __loop##name:                                                   \
-    if (!EGIT_EXTRACT_BOOLEAN(__cell##name)) goto __end##name;      \
-    if (!em_assert(env, em_cons_p, __cell##name)) return em_nil;    \
-    emacs_value (var) = em_car(env, __cell##name)
-
-/**
- * Close a loop over an Emacs lisp.
- * @param name: Unique name identifying the loop.
- */
-#define EGIT_DOLIST_END(name)                   \
-    __cell##name = em_cdr(env, __cell##name);   \
-    goto __loop##name;                          \
-    __end##name:
-
-/**
  * Enum used to distinguish between various types of git_??? structs.
  */
 typedef enum {
@@ -289,10 +164,10 @@ typedef enum {
  * User-pointers returned to Emacs should always wrap a struct of type egit_object.
  */
 typedef struct {
-    UT_hash_handle hh;          /**< For internal use by the hash table. */
-    egit_type type;             /**< Type of object stored. */
-    ptrdiff_t refcount;         /**< Reference count. */
-    void *ptr;                  /**< Pointer to git_??? structure. */
+    UT_hash_handle hh;                 /**< For internal use by the hash table. */
+    egit_type type;                    /**< Type of object stored. */
+    ptrdiff_t refcount;                /**< Reference count. */
+    void *ptr;                         /**< Pointer to git_??? structure. */
 } egit_object;
 
 /**

--- a/src/egit.h
+++ b/src/egit.h
@@ -163,12 +163,15 @@ typedef enum {
  *
  * User-pointers returned to Emacs should always wrap a struct of type egit_object.
  */
-typedef struct {
-    UT_hash_handle hh;                 /**< For internal use by the hash table. */
-    egit_type type;                    /**< Type of object stored. */
-    ptrdiff_t refcount;                /**< Reference count. */
-    void *ptr;                         /**< Pointer to git_??? structure. */
-} egit_object;
+typedef struct egit_object_s egit_object;
+
+struct egit_object_s {
+    UT_hash_handle hh;          /**< For internal use by the hash table. */
+    egit_type type;             /**< Type of object stored. */
+    ptrdiff_t refcount;         /**< Reference count. */
+    void *ptr;                  /**< Pointer to git_??? structure. */
+    egit_object *parent;        /**< Optional pointer to parent wrapper. */
+};
 
 /**
  * Return the git object type stored by en Emacs value.
@@ -204,7 +207,7 @@ bool egit_assert_object(emacs_env *env, emacs_value obj);
  * @param ptr The pointer to store.
  * @return The Emacs value.
  */
-emacs_value egit_wrap(emacs_env *env, egit_type type, void* ptr);
+emacs_value egit_wrap(emacs_env *env, egit_type type, void* ptr, egit_object *parent);
 
 /**
  * If libgit2 signaled an error, dispatch that error to Emacs.

--- a/src/interface.h
+++ b/src/interface.h
@@ -111,6 +111,10 @@ extern emacs_value em_from_owner, em_no_symlinks, em_no_filemode, em_ignore_case
 #define EM_EXTRACT_STRING_OR_NULL(val)                                  \
     (EM_EXTRACT_BOOLEAN(val) ? em_get_string(env, (val)) : NULL);
 
+// Extract a user pointer from an emacs_value.
+// Caller is responsible for ensuring that the emacs_value represents a user pointer.
+#define EM_EXTRACT_USER_PTR(val) env->get_user_ptr(env, (val))
+
 /**
  * Initiate a loop over an Emacs list.
  * If any element is not a cons cell or nil, it WILL signal an error and return nil.


### PR DESCRIPTION
This resolves a weakness that I found while working with diffs. In many cases, libgit2 exposes public structs which share data with an opaque type, examples being:

- `git_tree_entry` from `git_tree`
- `git_index_entry` from `git_index`
- `git_diff_delta` from `git_diff`
- `git_diff_hunk` from `git_diff`
- `git_diff_line` from `git_diff`

There are (at least) three different approaches to exposing such data to Emacs.

1. You can copy the data into a lispy data structure, like an alist or a plist. Then the parent object can go out of scope and the data is fine.
2. You can copy the data into a C structure that you allocate yourself, and expose an interface to Emacs through getter functions. Then the parent object can go out of scope and the data is fine.
3. You can expose a pointer to the shared data, and ensure that the parent object is kept alive even if it goes out of scope.

Each approach has some drawbacks and benefits.

(1) Feels lispy, however libegit2 already does not, and cannot really feel particularly lispy, being a thin wrapper around a C library. It also feels wrong to manually copy potentially large amounts of data before you know the caller needs it. In many cases the resulting objects can be large, for example several of these objects contain bit-flag fields with multiple booleans that we would have to unwrap. Almost all the other objects in libgit2 are exposed to lisp as opaque user pointers with getters, and it feels somehow strange to make exceptions.

(2) Avoids the issue of exposing to lips an unwieldy data structure, but maintains the burden of potentially unnecessary copying. The amount of getters needed may be large.

(3) Avoids unnecessary copying of data. The drawback here is that the child objects usually do not keep an explicit pointer to the parent object, so that with the current code we can't maintain the reference. This PR fixes that. Same drawback as (2) with lots of getters.

Currently, strategy (1) is used for `git_tree_entry` (because they are small), while strategy (2) is used for `git_index_entry` (because they are a bit bigger), and a weird mix is used for `git_status` where a bit-masked value masquerading as an integer is sent to Emacs, which can be decoded using `libgit-status-decode`.

This PR does the following.

- Move all the utility macros that are only relevant to the Emacs interface (but not libgit) to interface.h, where they really belong anyway.
- Shorten some of those damn doc comments in the headers.
- Add a new field to the `egit_object` struct pointing to a parent wrapper. Before we would find the parent wrapper by checking the type of the child, then calling `git_object_owner` or something like that, finally looking up the resulting pointer in a hash table. The problem being that there's no such function as `git_index_entry_owner` getting you the `git_index`. So now we can be more explicit.
- With this PR the `egit_wrap` function will fill in this parent pointer if not provided explicitly, using the same mechanism as we used to do. However in the future we can probably avoid that entirely and scrap the hash table.
- Implement strategy (3) for `git_index_entry` objects.

Long term I'd like to move to strategy (3) for all these situations, mostly because it avoids unnecessary copying of data, which just feels really wrong to me, and because it makes the interface feel a lot more uniform.