### PR TITLE
README.md: Update example borg configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ If you use [Borg](https://github.com/emacscollective/borg), the following `.gitm
 work.
 
 ```
-[submodule "libegit2"]
-    path = lib/libegit2
-    url = git@github.com:TheBB/libegit2.git
+[submodule "libgit"]
+    path = lib/libgit
+    url = git@github.com:magit/libegit2.git
     build-step = git submodule init
     build-step = git submodule update
     build-step = mkdir -p build


### PR DESCRIPTION
- Update the repository url.
- Change the name of the package from `libegit2` to `libgit`.
  On Melpa the package is named `libgit` too.  The package
  is also on the Emacsmirror, again under the name `libgit`.
  The name `libegit2` is more of an implementation detail;
  users load `libgit` when they want to use this.