### PR TITLE
Add new Makefile implementation, which can be used locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,12 @@ PACKAGE_BASENAME := libgit
 
 include emake.mk
 
-libgit2:                        ## pull down libgit2
-	git submodule init
-	git submodule update
+libgit2:
+	git submodule update --init
 
-build/libegit2.so: libgit2      ## build the module
+build/libegit2.so: libgit2
 	mkdir -p build
 	cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug && make
 
 test: EMACS_ARGS += -L build/ -l libegit2
-test: build/libegit2.so test-ert ## run tests
-
-clean:                          ## removes build directories
-	rm -rf build/
+test: build/libegit2.so test-ert

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+ifeq "$(TRAVIS)" "true"
+## Makefile for Travis ###################################################
+#
+#  TODO Move this to a separate file ".travis.mk" once Emake supports
+#  that.  (Apparently it already does, but I couldn't get it to work.)
+
 EMAKE_SHA1       ?= 1b23379eb5a9f82d3e2d227d0f217864e40f23e0
 PACKAGE_BASENAME := libgit
 
@@ -12,3 +18,96 @@ build/libegit2.so: libgit2
 
 test: EMACS_ARGS += -L build/ -l libegit2
 test: build/libegit2.so test-ert
+
+else
+## Makefile for local use ################################################
+
+-include .config.mk
+
+PKG = libgit
+
+ELS  = $(PKG).el
+ELCS = $(ELS:.el=.elc)
+
+EMACS      ?= emacs
+EMACS_ARGS ?=
+
+LOAD_PATH  ?= -L . -L build
+
+.PHONY: test
+
+all: lisp
+
+help:
+	$(info make all               - build everything)
+	$(info make module            - generate module)
+	$(info make lisp              - generate byte-code and autoloads)
+	$(info make submodule-init    - update the submodule)
+	$(info make submodule-update  - update the submodule)
+	$(info make test              - run tests)
+	$(info make clean             - remove generated files)
+	@printf "\n"
+
+module: build/libegit2.so
+
+build/libegit2.so: libgit2
+	@printf "Building $<\n"
+	@mkdir -p build
+	@cd build && cmake .. -DCMAKE_BUILD_TYPE=Debug && make
+
+lisp: $(ELCS) loaddefs module
+
+loaddefs: $(PKG)-autoloads.el
+
+%.elc: %.el
+	@printf "Compiling $<\n"
+	@$(EMACS) -Q --batch $(EMACS_ARGS) $(LOAD_PATH) -f batch-byte-compile $<
+
+test: libgit.elc build/libegit2.so
+	$(EMACS) -Q --batch $(LOAD_PATH) -l libgit \
+	  $(addprefix -l test/,$(shell ls test)) \
+	  -f ert-run-tests-batch-and-exit
+
+submodule-init: libgit2
+
+submodule-update: libgit2
+	git submodule update
+
+libgit2:
+	git submodule update --init
+
+CLEAN  = $(ELCS) $(PKG)-autoloads.el build
+
+clean:
+	@printf "Cleaning...\n"
+	@rm -rf $(CLEAN)
+
+define LOADDEFS_TMPL
+;;; $(PKG)-autoloads.el --- automatically extracted autoloads
+;;
+;;; Code:
+(add-to-list 'load-path (directory-file-name \
+(or (file-name-directory #$$) (car load-path))))
+
+;; Local Variables:
+;; version-control: never
+;; no-byte-compile: t
+;; no-update-autoloads: t
+;; End:
+;;; $(PKG)-autoloads.el ends here
+endef
+export LOADDEFS_TMPL
+#'
+
+$(PKG)-autoloads.el: $(ELS)
+	@printf "Generating $@\n"
+	@printf "%s" "$$LOADDEFS_TMPL" > $@
+	@$(EMACS) -Q --batch --eval "(progn\
+	(setq make-backup-files nil)\
+	(setq vc-handled-backends nil)\
+	(setq default-directory (file-truename default-directory))\
+	(setq generated-autoload-file (expand-file-name \"$@\"))\
+	(setq find-file-visit-truename t)\
+	(update-directory-autoloads default-directory))"
+
+endif


### PR DESCRIPTION
~~This is still under construction,~~ *Update:* See description below.

 but I needed a place to make the following request:

@npostavs Could you please rebuild the `emacs` binaries `--with-modules`? You might also want to enable issues on https://github.com/npostavs/emacs-travis. *Update:* I assume you do not intend to build any macOS binaries. If you could do that, that would be nice though.