### PR TITLE
Workaround a missing giterr in revparse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(EGIT_TESTS
   repository
   reset
   revert
+  revparse
   revwalk
   signature
   status

--- a/src/egit-revparse.c
+++ b/src/egit-revparse.c
@@ -76,6 +76,17 @@ emacs_value egit_revparse_single(emacs_env *env, emacs_value _repo, emacs_value 
         free(spec);
     }
     EGIT_CHECK_ERROR(retval);
+    if (retval == GIT_ENOTFOUND) {
+      // We can only reach this if a giterr was not set by libgit.
+      // This is a bug in libgit, bug report and fix are TBD.
+      // Let's signal this error manually.
+      emacs_value error = em_findenum_error(GITERR_REFERENCE);
+      if (!EM_EXTRACT_BOOLEAN(error))
+        error = esym_giterr;
+      em_signal(env, error,
+		"previously checked out branch or commit not found");
+      return esym_nil;
+    }
 
     return egit_wrap(env, EGIT_OBJECT, obj, EM_EXTRACT_USER_PTR(_repo));
 }

--- a/test/revparse-test.el
+++ b/test/revparse-test.el
@@ -29,3 +29,17 @@
           (should (car res))
           (should (string= c1 (libgit-commit-id (cadr res))))
           (should (string= c2 (libgit-commit-id (caddr res)))))))))
+
+(ert-deftest revparse-negative ()
+  (let (c1 c2 c3)
+    (with-temp-dir path
+      (init)
+      (commit-change "file1" "abcdef")
+      (let ((repo (libgit-repository-open path)))
+        (should-error (libgit-revparse-single repo "HEADDDD")
+		      :type 'giterr-reference)
+	(commit-change "file2" "abcdef")
+	(checkout "HEAD^")
+	(should (libgit-revparse-single repo "@{-1}"))
+	(should-error (libgit-revparse-single repo "@{-2}")
+		      :type 'giterr-reference)))))


### PR DESCRIPTION
In case of @{-N} revspec (which is an Nth previously checked out
branch or commit), libgit does not set a giterr and only return
GIT_ENOTFOUND and a NULL obj. In such cases, EGIT_CHECK_ERROR does not
return (it requires a non-NULL giterr_last()), and we crash on NULL
pointer (obj) dereference.

This patch adds a check for this situation, and a emulates what libgit
was supposed to do. Another patch is expected to libgit, so it should
work better in future releases.