### PR TITLE
Implement libgit-status-foreach-ext instead of libgit-status-foreach

### DIFF
--- a/src/egit-status.c
+++ b/src/egit-status.c
@@ -76,7 +76,7 @@ emacs_value egit_status_should_ignore_p(emacs_env *env, emacs_value _repo,
     return ignored == 0 ? esym_nil : esym_t;
 }
 
-EGIT_DOC(status_foreach, "REPO FUNCTION &optional SHOW FLAGS PATHSPEC BASELINE",
+EGIT_DOC(status_foreach_ext, "REPO FUNCTION &optional SHOW FLAGS PATHSPEC BASELINE",
          "Gather file statuses in REPO and call FUNCTION for each one.\n\n"
          "FUNCTION is called with two arguments: FILE and STATUS.\n"
          "FILE is path to a file, relative to the root directory.\n"
@@ -140,10 +140,10 @@ EGIT_DOC(status_foreach, "REPO FUNCTION &optional SHOW FLAGS PATHSPEC BASELINE",
          "BASELINE is the tree to be used for comparison to the working directory and\n"
          "index; defaults to HEAD."
     );
-emacs_value egit_status_foreach(emacs_env *env, emacs_value _repo,
-                                emacs_value function, emacs_value show,
-                                emacs_value flags, emacs_value pathspec,
-                                emacs_value baseline)
+emacs_value egit_status_foreach_ext(emacs_env *env, emacs_value _repo,
+                                    emacs_value function, emacs_value show,
+                                    emacs_value flags, emacs_value pathspec,
+                                    emacs_value baseline)
 {
     EGIT_ASSERT_REPOSITORY(_repo);
     EM_ASSERT_FUNCTION(function);
@@ -158,7 +158,7 @@ emacs_value egit_status_foreach(emacs_env *env, emacs_value _repo,
         return esym_nil;
 
     if (!EM_EXTRACT_BOOLEAN(flags))
-        options.flags = GIT_STATUS_OPT_DEFAULTS;
+        options.flags = 0;
     else if (!em_setflags_list(&options.flags, env, flags, true, em_setflag_status_opt))
         return esym_nil;
 

--- a/src/egit-status.h
+++ b/src/egit-status.h
@@ -5,7 +5,7 @@
 
 EGIT_DEFUN(status_decode, emacs_value _status);
 EGIT_DEFUN(status_file, emacs_value _repo, emacs_value _path);
-EGIT_DEFUN(status_foreach, emacs_value _repo, emacs_value function,
+EGIT_DEFUN(status_foreach_ext, emacs_value _repo, emacs_value function,
            emacs_value show, emacs_value flags, emacs_value pathspec,
            emacs_value baseline);
 EGIT_DEFUN(status_should_ignore_p, emacs_value _repo, emacs_value _path);

--- a/src/egit.c
+++ b/src/egit.c
@@ -786,7 +786,7 @@ void egit_init(emacs_env *env)
     DEFUN("libgit-status-decode", status_decode, 1, 1);
     DEFUN("libgit-status-file", status_file, 2, 2);
     DEFUN("libgit-status-should-ignore-p", status_should_ignore_p, 2, 2);
-    DEFUN("libgit-status-foreach", status_foreach, 2, 6);
+    DEFUN("libgit-status-foreach-ext", status_foreach_ext, 2, 6);
 
     // Submodule
     DEFUN("libgit-submodule-add-setup", submodule_add_setup, 3, 4);

--- a/test/status-test.el
+++ b/test/status-test.el
@@ -1,6 +1,6 @@
 (defun foreach-collect (repo &optional show flags pathspec baseline)
   (let (res)
-    (libgit-status-foreach
+    (libgit-status-foreach-ext
      repo
      (lambda (path status)
        (push (cons path (sort (libgit-status-decode status)
@@ -112,34 +112,37 @@
                 '("d/f*" "d/*z"))
                '(("d/baz" . (wt-new)) ("d/foo" . (wt-new)))))
 
-      (should-error (libgit-status-foreach repo nil) :type 'wrong-type-argument)
+      (should-error (libgit-status-foreach-ext repo nil) :type 'wrong-type-argument)
       (let ((i 0))
         (define-error 'foo "Foo")
         ;; Nonlocal exit test
-        (should-error (libgit-status-foreach
+        (should-error (libgit-status-foreach-ext
                        repo
                        (lambda (&rest args)
                          (when (= (cl-incf i) 2)
-                           (signal 'foo "f")))) :type 'foo)
+                           (signal 'foo "f")))
+		       nil
+		       '(include-untracked include-ignored include-unmodified))
+		       :type 'foo)
         (should (= i 2)))
-      (should-error (libgit-status-foreach repo #'ignore 'foo)
+      (should-error (libgit-status-foreach-ext repo #'ignore 'foo)
                     :type 'wrong-value-argument)
-      (should-error (libgit-status-foreach repo #'ignore nil 1)
+      (should-error (libgit-status-foreach-ext repo #'ignore nil 1)
                     :type 'wrong-type-argument)
-      (should-error (libgit-status-foreach repo #'ignore nil '(foo))
+      (should-error (libgit-status-foreach-ext repo #'ignore nil '(foo))
                     :type 'wrong-value-argument)
-      (should-error (libgit-status-foreach repo #'ignore nil nil 1)
+      (should-error (libgit-status-foreach-ext repo #'ignore nil nil 1)
                     :type 'wrong-type-argument)
-      (should-error (libgit-status-foreach repo #'ignore nil nil '(foo))
+      (should-error (libgit-status-foreach-ext repo #'ignore nil nil '(foo))
                     :type 'wrong-type-argument)
-      (should-error (libgit-status-foreach repo #'ignore nil nil nil 1)
+      (should-error (libgit-status-foreach-ext repo #'ignore nil nil nil 1)
                     :type 'wrong-type-argument)
-      (should-error (libgit-status-foreach repo #'ignore nil
+      (should-error (libgit-status-foreach-ext repo #'ignore nil
                                            '(no-refresh update-index))
                     :type 'giterr-invalid)
 
       ;; Should not error
-      (libgit-status-foreach
+      (libgit-status-foreach-ext
        repo #'ignore nil nil nil
        (libgit-reference-peel (libgit-repository-head repo) 'tree)))))
 


### PR DESCRIPTION
The git_status_foreach_ext function allows to pass zero or more flags,
while git_status_foreach is a simpler version that calls *-ext with
three default flags: include-untracked, include-ignored and
include-unmodified.

Before this patch, libgit-status-foreach tried to handle both
cases. When flags are nil it behaved like git_status_foreach, calling
git_status_foreach_ext with three default flags. When flags are
non-nil it called git_status_foreach_ext with the user-provided set of
flags.

The problem occurs when we want _no_ flags at all. We cannot pass an
empty list of flags because it is just nil, and we get those three
default flags instead.

So this patch changes the function (and its name) to behave just like
git_status_foreach_ext: no default flags are set when flags argument
is nil. Functionality of the old libgit-status-foreach can be
implemented by explicitly providing default flags:

    (libgit-status-foreach-ext repo (lambda ...) nil
      '(include-untracked include-ignored include-unmodified))