### PR TITLE
fix module loading on emacs 28 on mac os

### DIFF
--- a/libgit.el
+++ b/libgit.el
@@ -41,7 +41,12 @@
   "Directory where the libegit2 dynamic module file should be built.")
 
 (defvar libgit--module-file
-  (expand-file-name (concat "libegit2" module-file-suffix) libgit--build-dir)
+  (expand-file-name
+   (concat "libegit2" (if (and (string-equal system-type "darwin")
+                               (> emacs-major-version 27))
+                          ".so"
+                        module-file-suffix))
+   libgit--build-dir)
   "Path to the libegit2 dynamic module file.")
 
 (defun libgit--configure ()


### PR DESCRIPTION
https://github.com/emacs-mirror/emacs/blob/ac6ba689d1cdb2611a779f9eb032d5ce97c77742/etc/NEWS#L188
> ** On macOS, Emacs can now load dynamic modules with a ".dylib" suffix.
'module-file-suffix' now has the value ".dylib" on macOS, but the
".so" suffix is supported as well.

We discussed this problem in #1 