### PR TITLE
Fix package URL in commentary

### DIFF
--- a/libgit.el
+++ b/libgit.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2018 TheBB
 ;;
 ;; Author: Eivind Fonn <evfonn@gmail.com>
-;; URL: https://github.com/TheBB/libegit2
+;; URL: https://github.com/magit/libegit2
 ;; Version: 0.0.1
 ;; Keywords: git vc
 ;; Package-Requires: ((emacs "25.1"))


### PR DESCRIPTION
* `libgit.el`: Fix package URL in commentary.

----

[The MELPA libgit recipe](https://github.com/melpa/melpa/blob/master/recipes/libgit) references the magit/libegit2 repository, so installing the "libgit" package from MELPA installs a package that is built from magit/libegit2, but the package commentary in magit/libegit2 references the TheBB/libegit2 fork, so the installed package directs users there.  As a consequence, I opened a PR (https://github.com/TheBB/libegit2/pull/1) in the wrong repository (I think).