### PR TITLE
Always load .so on Darwin

### DIFF
--- a/libgit.el
+++ b/libgit.el
@@ -41,7 +41,7 @@
   "Directory where the libegit2 dynamic module file should be built.")
 
 (defvar libgit--module-file
-  (expand-file-name (concat "libegit2" module-file-suffix) libgit--build-dir)
+  (expand-file-name (concat "libegit2" (if (string= system-type "darwin") ".so" module-file-suffix)) libgit--build-dir)
   "Path to the libegit2 dynamic module file.")
 
 (defun libgit--configure ()


### PR DESCRIPTION
* On Emacs 28, `module-file-suffix` is ".dylib" on Darwin , but still module
  loading still supports ".so".  Since we are always building ".so" on Darwin, we
  should alway load a ".so" on Darwin too.

