### PR TITLE
libgit.el: Be able to load libegit2 from load-path if found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ EMACS_ARGS ?=
 
 LOAD_PATH  ?= -L . -L build
 
-.PHONY: test libgit2 submodule-update install
+.PHONY: test submodule-update install
 
 all: lisp
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+DESTDIR     ?=
+PREFIX      ?= /usr
+DATADIR     ?= $(PREFIX)/share
+BINDIR      ?= $(PREFIX)/bin
+LIBDIR      ?= $(PREFIX)/lib
+ELDIR       ?= $(DATADIR)/emacs/site-lisp
+DYNMODDRIR  ?= $(LIBDIR)/emacs/site-lisp
+
 BUILD_OPTIONS=-DCMAKE_BUILD_TYPE=Debug
 
 ifeq '$(findstring ;,$(PATH))' ';'
@@ -54,7 +62,7 @@ EMACS_ARGS ?=
 
 LOAD_PATH  ?= -L . -L build
 
-.PHONY: test libgit2 submodule-update
+.PHONY: test libgit2 submodule-update install
 
 all: lisp
 
@@ -135,3 +143,17 @@ $(PKG)-autoloads.el: $(ELS)
 	(update-directory-autoloads default-directory))"
 
 endif
+
+install-%-dynamic-module:
+	$(if $<, install -m755 -d $(DESTDIR)$(DYNMODDRIR))
+	$(if $<, install -m755 $^ $(DESTDIR)$(DYNMODDRIR))
+
+install-%-el:
+	$(if $<, install -m755 -d $(DESTDIR)$(ELDIR))
+	$(if $<, install -m644 $^ $(DESTDIR)$(ELDIR))
+
+install: $(addprefix install-, libgit-el libgit-dynamic-module)
+
+install-libgit-el: $(ELS) $(ELCS) $(PKG)-autoloads.el
+
+install-libgit-dynamic-module: build/libegit2.so

--- a/libgit.el
+++ b/libgit.el
@@ -53,8 +53,13 @@
   (expand-file-name "build" libgit--root)
   "Directory where the libegit2 dynamic module file should be built.")
 
-(defvar libgit--module-file
-  (expand-file-name "libegit2.so" libgit--build-dir)
+(defvar libgit--module-file-name
+  (file-name-with-extension "libegit2" module-file-suffix)
+  "Name of the libegit2 dynamic module file.")
+
+(defvar libgit--module-file-name-path
+  (expand-file-name libgit--module-file-name
+                    libgit--build-dir)
   "Path to the libegit2 dynamic module file.")
 
 (defun libgit--configure ()
@@ -90,7 +95,7 @@ On successful exit, pass control on to the load step."
   "Load the `libegit2' dynamic module.
 If that fails, then raise an error."
   (unless (featurep 'libegit2)
-    (load libgit--module-file nil t t))
+    (load libgit--module-file-name-path nil t t))
   (unless (featurep 'libegit2)
     (error "libgit: unable to load the libegit2 dynamic module")))
 
@@ -100,8 +105,11 @@ If that fails, then raise an error."
 If the module is not available, then offer to build it."
   (interactive)
   (cond
-   ((file-exists-p libgit--module-file)
-    (libgit--load))
+    ((file-exists-p libgit--module-file-name-path)
+     (libgit--load))
+    ((locate-library libgit--module-file-name t)
+     (setq libgit--module-file-name-path (locate-library libgit--module-file-name t))
+     (libgit--load))
    (libgit-auto-rebuild
     (libgit--configure))
    ((and (not noninteractive)


### PR DESCRIPTION
Prefer previously installed libegit2 but check first for libegit2 from
load-path if it wasn't build already.

I modeled this logic similarly as in Jinx or ZMQ.el

I'm going to package libgit, loading it from load-parh allows to prebuild libegit.so without patching the package.